### PR TITLE
ci(release): split testing out of the release pipeline (build + publish only)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,15 +18,15 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Build orva (server + CLI)
         run: make build
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload server log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: orva-server-log
           path: ${{ runner.temp }}/orva.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,47 +28,87 @@ on:
       tag:
         description: "release tag (e.g. v0.3.0) — required for workflow_dispatch"
         required: true
+      force:
+        description: "skip the verification gate (emergency / rc only)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write   # create releases, upload assets
   packages: write   # push to ghcr.io
+  actions: read     # gate job reads CI/e2e run status for the tagged commit
 
 env:
   IMAGE_NAME: ghcr.io/harsh-2002/orva
 
 jobs:
-  # ── 0. Validate — the release gate ───────────────────────────────────
-  # The release is the LAST step: nothing is built or published until this
-  # is green. Mirrors ci.yml's go job (vet + race tests over the full
-  # module) so a tag can never ship code whose tests fail. The build +
-  # publish jobs below all depend on it.
-  validate:
-    name: validate (vet + race tests)
+  # ── 0. Gate — verify, don't re-test ──────────────────────────────────
+  # The release pipeline does NOT run tests. All verification (shellcheck,
+  # go vet/test/build, ui build, docker smoke, full e2e) already ran on the
+  # PR and on the push to main. This job only CONFIRMS the tagged commit is
+  # green — a status lookup, not a test run — so the release stays fast while
+  # a tag can still never ship code whose tests failed. Every build job
+  # `needs: gate`. `workflow_dispatch` with force=true skips it (rc/emergency).
+  gate:
+    name: gate (verify CI + e2e already passed)
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
-        with:
-          node-version: "24"
-          cache: ""
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.26.x"
-          cache: false
-      - name: build ui + embed adapters
-        # //go:embed needs ui_dist + adapters populated before vet/test.
+      - name: resolve commit SHA for the tag
+        id: sha
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          make embed
-          make adapters-embed
-      - name: go vet
-        run: go vet ./...
-      - name: go test
-        run: go test -count=1 -race ./...
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+            SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq .sha 2>/dev/null || true)"
+            [ -z "$SHA" ] && SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" --jq .object.sha 2>/dev/null || true)"
+          else
+            SHA="${GITHUB_SHA}"
+          fi
+          [ -n "$SHA" ] || { echo "::error::could not resolve a commit SHA to gate on"; exit 1; }
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "gating on commit $SHA"
+
+      - name: require CI + e2e success on that commit
+        if: ${{ github.event.inputs.force != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Confirm the tagged commit's verification is green — a status lookup,
+          # not a test run. Poll until the workflow completes (handles tagging
+          # right after the merge push), bounded so a stuck check can't hang the
+          # release. `hard` = must exist and succeed; `soft` = must succeed IF it
+          # ran (ci.yml is path-filtered, so a docs-only release commit may have
+          # no CI run — e2e always runs on a main push and actually builds + runs
+          # the server, so it's the hard gate).
+          check() {
+            local wf="$1" mode="$2" deadline=$((SECONDS + 1200))  # ~20 min cap
+            while :; do
+              read -r status conclusion < <(gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}/runs?head_sha=${SHA}&per_page=1" \
+                --jq '.workflow_runs[0] | "\(.status) \(.conclusion)"' 2>/dev/null || echo "null null")
+              if [ "$status" = "null" ]; then
+                if [ "$mode" = "soft" ]; then echo "• $wf: no run for $SHA (path-filtered) — skipping"; return 0; fi
+                echo "::error::no $wf run for $SHA — commit was not verified (use force=true to override)"; return 1
+              fi
+              if [ "$status" = "completed" ]; then
+                [ "$conclusion" = "success" ] && { echo "✓ $wf succeeded for $SHA"; return 0; }
+                echo "::error::$wf for $SHA concluded '$conclusion' — refusing to release an unverified commit"; return 1
+              fi
+              [ $SECONDS -lt $deadline ] || { echo "::error::timed out waiting for $wf on $SHA"; return 1; }
+              echo "… $wf is '$status' for $SHA — waiting"; sleep 20
+            done
+          }
+          check e2e.yml hard
+          check ci.yml  soft
+          echo "gate passed: verification is green for $SHA"
 
   # ── 1. Go binary: matrix amd64 + arm64 ───────────────────────────────
   build-orva:
     name: build orva (${{ matrix.goarch }})
-    needs: validate
+    needs: gate
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -143,7 +183,7 @@ jobs:
   # Windows builds get the .exe suffix.
   build-cli:
     name: build orva-cli (${{ matrix.goos }}/${{ matrix.goarch }})
-    needs: validate
+    needs: gate
     runs-on: ubuntu-24.04
     strategy:
       matrix:
@@ -231,7 +271,7 @@ jobs:
   # (Linux ≥ 3.2, which covers every system anyone deploys this on).
   build-nsjail:
     name: build nsjail (${{ matrix.goarch }})
-    needs: validate
+    needs: gate
     runs-on: ${{ matrix.runner }}
     container: debian:bookworm-slim
     strategy:
@@ -278,7 +318,7 @@ jobs:
   # ── 3. Language rootfs tarballs ───────────────────────────────────────
   build-rootfs:
     name: rootfs ${{ matrix.runtime }} (${{ matrix.goarch }})
-    needs: validate
+    needs: gate
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -437,7 +477,7 @@ jobs:
   # two digests into both `:latest` and the immutable `:${tag}`.
   docker-image:
     name: docker image (${{ matrix.goarch }})
-    needs: validate
+    needs: gate
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,15 +64,32 @@ Dockerfile        Multi-stage image (dev and production — single file)
 
 ## Release Policy
 
-**One active release at a time** — and **validate first, release last**. Order matters: never delete the old release *before* the new one is live (that opens a window where `install.sh`/`install-cli.sh` resolve "latest" → 404). The flow:
+**Two single-purpose pipelines: verify on push/PR, ship on tag.** The release pipeline does
+**no testing** — it gates on the tagged commit's checks already being green, then builds and
+publishes. All verification (`ci` = shellcheck + go vet/test/build + ui build + docker smoke,
+and `e2e` = full programmatic suite) runs on every PR and on the push to `main`; `cli-e2e` /
+`install-e2e` cover the CLI + bare-metal install (on PR for source, on `release:published`
+against the real artifacts).
 
-1. **Merge to `main`** and wait for **CI** + **e2e** to go green on the merge commit (these build from source — no release needed).
+**One active release at a time** — never delete the old release *before* the new one is live
+(that opens a window where `install.sh`/`install-cli.sh` resolve "latest" → 404). The flow:
+
+1. **Merge to `main`** and wait for **CI** + **e2e** to go green on the merge commit. This is the
+   verification — the release will not re-run it.
 2. **Tag today's date and push** (zero-padded `vYYYY.MM.DD`):
    ```bash
    git tag -a v2026.05.03 -m "Orva v2026.05.03" && git push origin v2026.05.03
    ```
-   The Release workflow then **validates** (`go vet` + race tests) and *only on success* builds + publishes `ghcr.io/harsh-2002/orva:latest` (multi-arch), all CLI binaries, rootfs tarballs, checksums, and the GitHub Release. Nothing is built or published if validation fails (every build job `needs: validate`).
-3. **On release publish**, `install-e2e` and `cli-e2e` run automatically against the freshly-published artifacts (they no longer trigger on main-push, which used to race the release cut).
+   The Release workflow's **`gate`** job confirms `CI` + `e2e` already concluded `success` for
+   that exact commit (a status lookup — seconds, not a test run; it polls briefly if you tag
+   right after the merge). It **refuses to build** if either is missing or red. On pass it builds
+   + publishes `ghcr.io/harsh-2002/orva:latest` (multi-arch), all CLI binaries, rootfs tarballs,
+   checksums, and the GitHub Release, then redeploys + prunes ghcr. Every build job `needs: gate`.
+   *Emergency/rc only:* `workflow_dispatch` with `force=true` skips the gate.
+3. **On release publish**, dispatch `install-e2e` + `cli-e2e` against the freshly-published
+   artifacts (a `GITHUB_TOKEN`-created release does not auto-fire downstream workflows, so trigger
+   them with `gh workflow run`). The `cli-e2e` upgrade-leg upgrades from the *previous* release's
+   binary, so it stays red until the next release makes this one the baseline — expected.
 4. **After** the new release is confirmed live, prune the previous one — last, not first:
    ```bash
    gh release delete v<old-tag> --yes --cleanup-tag   # removes the release + its tag


### PR DESCRIPTION
## Summary

Split testing out of the release pipeline so **a release builds and publishes only — fast, no tests**. Verification stays where it belongs (push/PR); the release just confirms the tagged commit is already green, then ships.

### Before
`release.yml` started with a `validate` job (`go vet` + `-race` tests + UI build) that every build job `needs:` — re-running the full suite that `ci.yml` + `e2e.yml` already ran on the same commit.

### After
- **`release.yml`**: `validate` → a tiny **`gate`** job that *verifies, doesn't re-test*. It resolves the tag → commit SHA and confirms **`e2e` succeeded** (hard) and **`ci` succeeded if it ran** (soft — `ci.yml` is path-filtered for docs; `e2e` always runs on a main push and actually builds+runs the server). Polls briefly to absorb a tag-right-after-merge race; refuses to build an unverified commit. All build jobs `needs: gate`. New `force` `workflow_dispatch` input (emergency/rc bypass) + `actions: read` permission. **No `go test`/`go vet` remains in the release.**
- **CLAUDE.md**: Release Policy rewritten to the two-pipeline model (verify on push/PR; ship on tag, gated on already-green checks).
- **e2e.yml**: action-version bumps (checkout/setup-go/setup-python/upload-artifact) + python 3.14 to match `ci.yml`. No behavior change.

## Why
The release should be fast and single-purpose (ship). Testing belongs in the on-push/PR pipeline. The gate keeps the safety guarantee ("never ship a commit whose tests failed") as a status lookup (seconds), not a re-run.

## Validation
- YAML valid; gate logic handles: tag-push, workflow_dispatch (+force), tag-right-after-merge race, and path-filtered/docs commits.
- CI + e2e on this PR are exactly what the new gate will check on the merge commit.
- Next release (`v2026.06.05`) will be the first cut on the new pipeline — gate passes in seconds, then build+publish only.

No app code touched; test coverage unchanged — it just no longer runs *inside* the release.
