### PR TITLE
fix(deps): bump goldmark to v1.7.17 (GO-2026-5320)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -110,7 +110,7 @@ require (
 	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	github.com/yuin/goldmark v1.7.13 // indirect
+	github.com/yuin/goldmark v1.7.17 // indirect
 	github.com/yuin/goldmark-emoji v1.0.6 // indirect
 	gitlab.com/gitlab-org/api/client-go v1.46.0 // indirect
 	go.starlark.net v0.0.0-20260102030733-3fee463870c9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -272,8 +272,8 @@ github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZ
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
-github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
-github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
+github.com/yuin/goldmark v1.7.17 h1:p36OVWwRb246iHxA/U4p8OPEpOTESm4n+g+8t0EE5uA=
+github.com/yuin/goldmark v1.7.17/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 github.com/yuin/goldmark-emoji v1.0.6 h1:QWfF2FYaXwL74tfGOW5izeiZepUDroDJfWubQI9HTHs=
 github.com/yuin/goldmark-emoji v1.0.6/go.mod h1:ukxJDKFpdFb5x0a5HqbdlcKtebh086iJpI31LTKmWuA=
 gitlab.com/gitlab-org/api/client-go v1.46.0 h1:YxBWFZIFYKcGESCb9fpkwzouo+apyB9pr/XTWzNoL24=


### PR DESCRIPTION
A `govulncheck ./...` scan of `main` (after PR #34) flagged one remaining fixable Go vulnerability that Dependabot's group bump did not cover.

- **GO-2026-5320** — `github.com/yuin/goldmark` `<v1.7.17`, pulled transitively via `charmbracelet/glamour` for `orva chat` / `orva docs` markdown rendering. Bumped to the fixed **v1.7.17** (minimal fix; stays on the 1.7.x line to avoid glamour-compat risk from 1.8.x).

### Vuln posture after this PR
- ✅ GO-2026-5970 (`x/text`) — fixed by #34 (x/text → v0.40.0)
- ✅ GO-2026-5320 (`goldmark`) — fixed here
- ⚠️ GO-2026-5932 (`golang.org/x/crypto/openpgp`, unmaintained/unsafe-by-design) — **no fix released**; reached only via `go-selfupdate`'s signature code in `orva upgrade`. Orva verifies releases with sha256 `checksums.txt`, not PGP, so the path is effectively dead. Accepted/monitored — resolving it needs `go-selfupdate` to drop openpgp.

`go build ./...` + `go test ./...` green; go.mod/go.sum diff is the goldmark bump only (3 lines).