### PR TITLE
docs(agents): agent-ready for Codex/Claude/opencode + CONTRACT.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,39 @@ jobs:
               - 'test/release/**'
               - '.github/workflows/ci.yml'
 
+  # ── Agent-doc mirror guard ─────────────────────────────────────────────
+  # Every directory with a CLAUDE.md must also have an AGENTS.md symlink -> it,
+  # so Codex/opencode (which discover AGENTS.md) get the same per-directory
+  # context Claude Code gets from CLAUDE.md. Runs unconditionally (NOT behind
+  # the `code` path filter) because adding a CLAUDE.md without its AGENTS.md is
+  # a docs-only change that would otherwise skip the lint job. Also catches a
+  # symlink that got committed as literal text (e.g. a Windows checkout).
+  agent-docs:
+    name: agent-doc mirror (AGENTS.md ↔ CLAUDE.md)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - name: every CLAUDE.md dir has an AGENTS.md symlink -> CLAUDE.md
+        run: |
+          fail=0
+          for f in $(git ls-files '*CLAUDE.md'); do
+            d=$(dirname "$f")
+            case "$d" in .) a="AGENTS.md" ;; *) a="$d/AGENTS.md" ;; esac
+            mode=$(git ls-files -s "$a" | awk '{print $1}')
+            if [ "$mode" != "120000" ]; then
+              echo "::error file=$a::missing or not a symlink (git mode '${mode:-none}', want 120000). Run: (cd $d && ln -s CLAUDE.md AGENTS.md)"
+              fail=1; continue
+            fi
+            tgt=$(git show ":$a")
+            if [ "$tgt" != "CLAUDE.md" ]; then
+              echo "::error file=$a::points at '$tgt', want 'CLAUDE.md' (single-hop sibling symlink)"
+              fail=1
+            fi
+          done
+          [ "$fail" = 0 ] && echo "OK: every CLAUDE.md dir mirrors an AGENTS.md -> CLAUDE.md symlink"
+          exit $fail
+
   # ── Fast lint/build/unit gate ──────────────────────────────────────────
   lint:
     name: workflow + shell lint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Self-hosted Function-as-a-Service (FaaS) for homelab and on-premises use. Users write JavaScript (Node.js 24), Python (3.14), or TypeScript functions — two generic runtimes, `node` and `python`, latest-stable only; Orva deploys them into nsjail sandboxes and exposes them over HTTP with a built-in dashboard, CLI, MCP server, and an in-product AI chat assistant (the **AI** sidebar section) that operates the instance end-to-end via in-process tool calling (BYO provider keys, embedded Bifrost gateway).
 
+> **Operational contract:** read [`CONTRACT.md`](CONTRACT.md) **before proposing changes** — the canonical commands, build/CI invariants, ports, and must-not-break rules. Each directory's `CLAUDE.md` (mirrored as `AGENTS.md` so Codex/opencode read it too) covers how that subsystem works.
+
+@CONTRACT.md
+
 ## Quick Start
 
 ```bash

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -1,0 +1,153 @@
+# Orva — agent operating contract
+
+The single, canonical, present-tense operating contract for anyone (human or AI
+agent) changing this repo. Read this **before** proposing changes. It is the one
+place the load-bearing operational facts live; `CLAUDE.md`/`AGENTS.md` and
+`docs/CONTRIBUTING.md` reference it rather than restating it, so it cannot drift.
+
+- **Orientation** (what each subsystem is / how it works): the per-directory
+  `CLAUDE.md` (root + `backend/`, `cli/`, `frontend/`, `docs/`, `scripts/`,
+  `test/`, `test/e2e/`). Each is mirrored by an `AGENTS.md` symlink so
+  Codex/opencode read it too.
+- **This file** (`CONTRACT.md`): the mechanical rules that make a change land green.
+- **Human onboarding / PR etiquette**: `docs/CONTRIBUTING.md`.
+
+> All commands run from the **repo root** unless stated otherwise. This repo uses
+> tracked symlinks (`AGENTS.md` → `CLAUDE.md`); on Windows, clone with
+> `git clone -c core.symlinks=true …` or the mirrors materialize as plain text.
+
+## 1. Toolchain (pinned, lock-step)
+
+- **Go 1.26+** (the embedded Bifrost AI gateway requires it), **Node.js 24**,
+  **Python 3.14**.
+- **nsjail** on `PATH` (Linux only). The server starts without it, but **every
+  function invocation fails until nsjail is installed**. The Docker image ships it
+  at `/usr/local/bin/nsjail`.
+- One **`go.mod` at the repo root**, module `github.com/Harsh-2002/Orva`, spanning
+  `backend/` + `cli/` + `internal/`. The shared `internal/ids` and `internal/client`
+  live at **repo-root `internal/`** (NOT `backend/internal/`) because the slim CLI
+  imports them.
+- Versions are held **lock-step** across `Dockerfile`, `.github/workflows/ci.yml`,
+  and `.github/workflows/release.yml` — bump them together.
+
+## 2. Canonical commands
+
+| Command | Does |
+|---|---|
+| `make build` | server binary → `build/orva` (runs `adapters-embed` + `docs-embed` first) |
+| `make build-all` | `embed` (rebuild UI) **then** `build` — full release artifact |
+| `make test` | `go test -count=1 ./...` |
+| `make lint` | `go vet ./...` |
+| `make ui` / `make embed` | build the Vue UI / build UI **and** copy `dist/` → `backend/internal/server/ui_dist/` |
+| `make cli` / `make cli-all` | slim CLI (current OS) / cross-compile all 6 release targets |
+| `make adapters-embed` | sync `backend/runtimes/` → `backend/cmd/orva/adapters/` (for `//go:embed`) |
+| `make docs-embed` | sync `docs/reference.md` → its 3 embedded copies (§4) |
+| `make dev` | frontend hot-reload (:5173) + backend foreground |
+| `make clean` | remove `build/` + embedded artifacts |
+
+## 3. Build invariants (silent-stale-artifact traps)
+
+- **`adapters-embed` must run before any bare `go build`.** It copies `runtimes/`
+  into `backend/cmd/orva/adapters/` for `//go:embed`. `make build` does it; a raw
+  `go build ./backend/cmd/orva` does **not**.
+- **The UI is embedded via `//go:embed ui_dist`.** `make build` reuses the **last
+  embedded snapshot**. To pick up frontend changes you must run `make build-all`
+  (or `make embed` first) — `ui_dist/` is committed, so a stale snapshot ships
+  silently otherwise.
+
+## 4. Docs single source
+
+`docs/reference.md` is **canonical**. `make docs-embed` copies it **byte-identically**
+to three consumers (using `{{ORIGIN}}` placeholders substituted at runtime):
+
+- `backend/internal/mcp/reference.md` — embedded by the `get_orva_docs` MCP tool
+- `frontend/public/docs.md` — served at `/docs.md` (dashboard "Copy as Markdown")
+- `cli/commands/reference.md` — embedded by `orva docs`
+
+**Edit `docs/reference.md`, then run `make docs-embed`. Never edit a copy directly.**
+(The dashboard's rendered Docs page `frontend/src/views/Docs.vue` is a separate
+hand-maintained view — update it alongside if content changes.)
+
+## 5. Ports & data
+
+| Context | Port |
+|---|---|
+| Server (`orva serve`) | **8443** |
+| Docker compose host map | **3000 → 8443** |
+| Frontend dev server | **5173** |
+| Shell tests (`test/`) default `BASE_URL` | **18443** |
+| Python E2E (`test/e2e/`) | **8443** |
+
+- **Data dir** `/var/lib/orva` (env `ORVA_DATA_DIR`) — `orva.db` (SQLite WAL) +
+  `functions/<id>/versions/`.
+- **Server config is environment variables only** (`docs/CONFIG.md`); there is no
+  server config file. **CLI config** is `~/.orva/config.yaml` (`endpoint` + `api_key`).
+
+## 6. Definition of Done (minimum green)
+
+- **Fast, host-only** (always run before proposing a change):
+  `make lint` && `make test`.
+- **Authoritative** (the CI gate): the full E2E suite `test/e2e/run.py` (isolated
+  Docker; needs a built `build/orva`) plus the shell suites (`test/run-all.sh`
+  against a live instance). These require **Docker + nsjail + `ORVA_REQUIRE_SANDBOX=1`**
+  on a provisioned Linux host, where **real deploy/invoke is mandatory and a sandbox
+  skip is a hard failure**. If you cannot run these locally, say so — do not claim a
+  change is verified on `make test` alone.
+
+## 7. CI / release model
+
+- **Exactly two workflows**, and no others should be added without good reason:
+  `ci.yml` (**all** verification) and `release.yml` (**build + publish only, no
+  testing**).
+- **Two-stage: verify on push/PR, ship on tag.** `ci.yml` runs on PRs and every push
+  to `main` (docs-only changes skip only the fast lint/go/ui/docker jobs).
+- **Ship on `vYYYY.MM.DD` tag** (zero-padded). `release.yml`'s `gate` job confirms
+  `CI` already concluded `success` for that exact commit (a status lookup, not a
+  re-run), then builds + publishes. It refuses to build on missing/red CI.
+- Releases resolve GitHub's "latest": if you delete an old release by hand, **publish
+  the new one first** or "latest" 404s.
+- **Build-time identity** — `version.Version/Commit/BuildTime` via `-X` ldflags flow
+  **Makefile → Dockerfile → release.yml**. Go silently ignores unknown `-X` targets,
+  so renaming the `version` package or its vars must be done in **all three** or the
+  binary ships `dev`/`unknown`.
+
+## 8. CLI hard constraints (`cli/`)
+
+- **No `backend/internal/…` imports** (keeps the slim CLI slim — lift shared code to
+  repo-root `internal/` first, like `internal/ids`, `internal/client`).
+- **No CGO** — all binaries are pure-Go static (must run on a fresh Alpine).
+- **No `os.Exit` in subcommand bodies** — use `RunE` and return errors.
+- New top-level commands **must** be registered in `RegisterClient` (`cli/commands/root.go`),
+  assigned a group, and added to `cli/commands/commands_test.go`
+  (`TestCommandTree` + `TestRequiredFlagsPresent`) — or the command-tree golden diff fails.
+
+## 9. Must-not-break invariants
+
+- **SQLite migrations are additive-only** (`CREATE TABLE IF NOT EXISTS` + idempotent
+  `ALTER`), run on every boot. No `DROP`/destructive migrations.
+- `execution_requests` has **no FK** to `executions` (intentional, for async insert
+  ordering); the cascade is manual in `DeleteExecution`.
+- **TypeScript deploys** rewrite the function's `Entrypoint` to `dist/handler.js`
+  after a successful `tsc`; the validator on re-deploy checks the source `.ts`.
+- **nsjail `cmd.Wait()` is centralized in `Spawn`** (via `waitDone`); never call
+  `Wait()` on a sandbox `cmd` elsewhere (zombie-nsjail regression).
+- The AI agent's `defaultSystemPrompt` (`backend/internal/ai/manager.go`) is a Go
+  **raw string — it must stay backtick-free**.
+- **One AI turn per conversation** — a keyed try-lock rejects overlapping turns
+  (SSE `error` / `409 ErrConversationBusy`); `ai_messages.seq` is assigned atomically
+  inside the INSERT.
+- **AI conversation edit/delete is destructive-tail**: it truncates the conversation
+  at that message's `seq` (deletes it and everything after), then re-runs. No branching.
+- `scripts/entrypoint.sh` **overwrites the runtime adapters** from the image on every
+  container start (so runtime upgrades roll out even with a persistent volume).
+- Installers **SHA-256-verify** downloads against `checksums.txt` with **no fail-open
+  path** and no bypass env var.
+
+## 10. Code style
+
+- Go: `slog` with structured kv pairs (never `log.Printf`); wrap errors with
+  `fmt.Errorf("ctx: %w", err)` so `errors.Is` works; prefer `t.Run` subtests, use `-race`.
+- Vue: Composition API + `<script setup>` only; Pinia for state (no Vuex, no Options API
+  in new code).
+- Handlers respond via `respond.JSON` / `respond.Error` (`backend/internal/server/handlers/respond/`).
+- Comments explain the **why**, not the **what**.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 Orva is in active development. PRs welcome — for bug fixes especially,
 and for the items called out as "not yet shipped" in the README.
 
+> The canonical build/test commands, CI gates, ports, and must-not-break
+> invariants live in [`../CONTRACT.md`](../CONTRACT.md) (the repo's agent/operator
+> contract). This guide is the human-onboarding companion; where they overlap,
+> `CONTRACT.md` is the source of truth.
+
 ## Dev setup
 
 ```bash
@@ -167,67 +172,15 @@ The same harness drives the installer jobs in `.github/workflows/ci.yml`.
 - **Vue**: composition API + `<script setup>`. Pinia for store state.
   No vuex. No options API in new code.
 
-## CI
+## CI & releasing
 
-Two stages: **verify on push/PR, ship on tag.** All testing lives in the
-consolidated `CI` workflow; the release workflow does no testing.
-
-Verification (on push to `main` + every PR):
-
-- **`ci.yml`** — a single workflow covering both the fast gate (shellcheck,
-  go vet/test/build, frontend build, docker smoke build — path-filtered
-  internally, so docs-only changes skip only these jobs) and the full E2E
-  suites: programmatic source API/sandbox tests plus CLI build/install and
-  bare-metal installer matrices on every `main` push (path-selected on PRs).
-  Its `artifacts` suite validates every published CLI/server asset on Linux,
-  macOS, Windows, amd64, and arm64.
-
-Ship (on `v*` tag push):
-
-- **`release.yml`** — a fast **`gate`** job verifies the tagged commit's `CI`
-  already concluded `success` (a status lookup, not a re-run), then builds
-  the multi-arch Docker image, all CLI binaries, rootfs tarballs, and checksums,
-  and publishes the GitHub Release + `ghcr.io/harsh-2002/orva`. **No tests run in
-  the release** — it trusts the already-green checks on that exact SHA. A
-  `workflow_dispatch` with `force=true` bypasses the gate only for an emergency
-  rebuild and still checks out the exact stable date tag supplied to the workflow.
-Those two are the only workflows — `ci.yml` tests, `release.yml` ships. Nothing
-prunes old releases, tags, or untagged GHCR manifests automatically; delete them
-by hand from the Releases page / GHCR package settings if they ever pile up.
-
-## Releasing
-
-Releases accumulate, and `install.sh` / `install-cli.sh` always resolve GitHub's
-"latest" (the newest published release). If you do delete an old release by hand,
-publish the new one *first* — removing the current release before its replacement
-is live opens a window where "latest" resolves to 404. The flow:
-
-1. **Merge to `main`** and wait for **`CI`** to go green on the merge
-   commit. This is the verification — the release will not re-run it.
-2. **Tag today's date (zero-padded) and push:**
-
-   ```bash
-   git tag -a v$(date -u +%Y.%m.%d) -m "Orva v$(date -u +%Y.%m.%d)"
-   git push origin v$(date -u +%Y.%m.%d)
-   ```
-
-   The release's `gate` confirms `CI` already passed for that commit
-   (seconds, not a test run; it polls briefly if you tag right after the merge)
-   and refuses to build if it is missing or red. On pass it builds + publishes
-   everything; the arm64 rootfs builds are the slowest leg.
-3. **On release publish**, `release.yml` automatically dispatches the consolidated
-   released-artifact suite (a `GITHUB_TOKEN`-created release does not auto-fire
-   downstream workflows, so the release job performs the dispatch explicitly).
-   Use this command only to retry that suite manually:
-
-   ```bash
-   gh workflow run ci.yml -f suite=artifacts -f tag=vYYYY.MM.DD
-   ```
-
-4. That green `artifacts` run is the end of the pipeline — nothing runs after it.
-
-The full policy (gate internals, force bypass, build-time identity stamping) lives
-in the root `CLAUDE.md`.
+The CI/release model — two workflows (`ci.yml` verifies, `release.yml` ships),
+verify-on-push/PR + ship-on-`vYYYY.MM.DD`-tag, the `gate` job, the
+publish-before-delete "latest 404" rule, and build-time identity stamping — is the
+canonical operating contract and lives in one place: [`../CONTRACT.md`](../CONTRACT.md)
+(§6 Definition of Done, §7 CI/release model). It is intentionally **not** restated
+here so it can't drift. The deeper release-policy walkthrough (tag/gate/artifacts
+steps) is in the root [`CLAUDE.md`](../CLAUDE.md).
 
 ## Filing issues
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": ["CONTRACT.md", "**/CLAUDE.md"]
+}

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Makes the repo work equally well under **Codex, Claude, and opencode** (only those three, per request), and adds a single canonical operating contract.

### Problem
Claude Code reads the per-directory `CLAUDE.md` natively, but **Codex** and **opencode** discover instructions via `AGENTS.md` — which existed **only at the repo root**. An agent working inside `backend/`, `cli/`, etc. lost the subsystem guidance under those two tools. Operational facts (commands, CI gates, invariants) were also spread across the `CLAUDE.md` set **and duplicated** in `docs/CONTRIBUTING.md` (Release policy stated twice).

### Changes
- **7 nested `AGENTS.md` → `CLAUDE.md` symlinks** (git mode `120000`, single-hop sibling) in `backend/ cli/ frontend/ docs/ scripts/ test/ test/e2e/`, mirroring the root. Codex gets the nested chain; opencode gets subdir context; Claude is unaffected. **Zero duplication** — the symlinks *are* the `CLAUDE.md`.
- **`opencode.json`** (root): `instructions: ["CONTRACT.md", "**/CLAUDE.md"]` so a root-launched opencode loads the whole tree + the contract.
- **`CONTRACT.md`** (new): the one canonical operating contract — toolchain pins, commands, the `adapters-embed`/`docs-embed` invariants, ports, Definition of Done, CI/release model, CLI hard constraints, must-not-break invariants, code style. Referenced from root `CLAUDE.md` via a prose pointer (Codex/opencode) **and** a `@CONTRACT.md` import (Claude).
- **Dedupe `docs/CONTRIBUTING.md`**: collapse the twice-stated CI/Releasing prose into a pointer to `CONTRACT.md`.
- **`ci.yml` guard**: an always-run `agent-docs` job asserts every `CLAUDE.md` dir has an `AGENTS.md` symlink → `CLAUDE.md` (catches a forgotten mirror or a symlink committed as literal text). Runs outside the `code` path filter since adding a `CLAUDE.md` is a docs-only change.

### Strategy (best-practice, zero-drift)
`CLAUDE.md` stays canonical everywhere; `AGENTS.md` are single-hop symlinks (no chains, no copied prose); `opencode.json` lists *paths* not content; `CONTRACT.md` is the **only** home for the operational facts.

### Grounding / safety
Codex reads `AGENTS.md` hierarchically with a **32 KiB combined cap**; the current deepest chain is ~21 KB and `CONTRACT.md` is *referenced*, not inlined, so it stays clear. Docs/symlinks/CI only — **no Go code changed**; `go vet` + `actionlint` clean, drift-guard passes locally.