### PR TITLE
fix(install): resolve the release tag without depending on the GitHub API

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -527,14 +527,57 @@ ensure_downloader() {
 }
 
 # ── Version resolution ───────────────────────────────────────────────────────
+#
+# Two independent sources, because the API one is rate-limited and that limit
+# is shared by IP. Unauthenticated api.github.com allows 60 requests/hour, so
+# a NAT'd office, a CI runner, or a second install on the same box gets a 403
+# and the install dies with "could not resolve latest release tag" -- which
+# reads like Orva has no releases, not like a rate limit. curl --retry does
+# not help: 403 is not a transient status, so it is never retried.
+#
+# The fallback is the plain /releases/latest redirect, which is ordinary web
+# traffic rather than API traffic and is not subject to that quota. It
+# resolves to .../releases/tag/<tag>, so the tag is the last path segment.
 resolve_version() {
     if [ -n "$VERSION" ]; then log "version: $VERSION"; return; fi
     if [ "$DRYRUN" = "1" ]; then VERSION="latest"; log "version: latest (dryrun)"; return; fi
     log "resolving latest release from GitHub"
-    VERSION=$(curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 15 \
-        "https://api.github.com/repos/${REPO}/releases/latest" \
-        | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)
-    [ -n "$VERSION" ] || die "could not resolve latest release tag (pass --version)"
+
+    # An authenticated call gets 5000/hour instead of 60. Honour a token if
+    # the environment already has one (CI usually does); never require it.
+    rv_auth=""
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        rv_auth="Authorization: Bearer ${GITHUB_TOKEN}"
+    fi
+
+    if [ -n "$rv_auth" ]; then
+        VERSION=$(curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 15 \
+            -H "$rv_auth" "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)
+    else
+        VERSION=$(curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 15 \
+            "https://api.github.com/repos/${REPO}/releases/latest" 2>/dev/null \
+            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' | head -n1)
+    fi
+
+    if [ -z "$VERSION" ]; then
+        warn "GitHub API did not answer (rate limit?) — falling back to the release redirect"
+        rv_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' --retry 3 --retry-delay 2 \
+            --connect-timeout 15 "https://github.com/${REPO}/releases/latest" 2>/dev/null)
+        case "$rv_url" in
+            */releases/tag/*) VERSION="${rv_url##*/}" ;;
+            *)                VERSION="" ;;
+        esac
+    fi
+
+    # Guard against a redirect that lands somewhere unexpected: every Orva tag
+    # is vYYYY.MM.DD, and feeding a bogus value downstream would build asset
+    # URLs that 404 much later with a far less obvious message.
+    case "$VERSION" in
+        v[0-9][0-9][0-9][0-9].[0-9][0-9].[0-9][0-9]) ;;
+        "") die "could not resolve latest release tag (pass --version)" ;;
+        *)  die "resolved an unexpected release tag '$VERSION' (pass --version)" ;;
+    esac
     log "version: $VERSION"
 }
 


### PR DESCRIPTION
`install.sh` asked `api.github.com` for the latest release and had nothing to fall back on. Unauthenticated, that endpoint allows **60 requests/hour per IP** — so a NAT'd office, a CI runner, or a second install on the same box gets a `403` and the install dies with:

```
could not resolve latest release tag (pass --version)
```

which reads like Orva has no releases rather than like a rate limit. The existing `curl --retry 3` never helped: `403` is not a transient status, so curl does not retry it.

**Not hypothetical.** It failed CI's `rocky9` installer job on this repo today, and an earlier run on `main` had **five of six** installer jobs fail together — the signature of a shared per-IP quota. Both passed on re-run. A real operator installing from a busy address hits the same wall with no re-run button.

## Changes

- **Fall back to the `/releases/latest` redirect.** Ordinary web traffic, not API traffic, so it isn't subject to that quota. It resolves to `.../releases/tag/<tag>`, so the tag is the last path segment.
- **Honour `GITHUB_TOKEN` if the environment already has one** (5000/hour instead of 60). Never required — which also fixes CI without the workflow changing.
- **Validate the result.** Every Orva tag is `vYYYY.MM.DD`; a redirect landing somewhere unexpected would otherwise be pasted into asset URLs and surface much later as a 404 on a download, with nothing pointing back here.

## Verification

`resolve_version` exercised in isolation across all five paths:

| Path | Result |
|---|---|
| API reachable | `v2026.08.05` |
| API broken | falls back, resolves the **same** tag |
| Both sources broken | dies with the original message |
| Malformed tag | rejected by name |
| `--version` / `--dryrun` | short-circuit, no network |

`bash -n`, `dash -n` and `shellcheck` all clean.

Opened as a PR rather than pushed to `main` because the six distro installer jobs are the real gate here and can't be run locally.