### PR TITLE
fix: make credential revocation evict the caches that answer for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,30 @@ the commit messages; `git log v2026.08.05..HEAD` is the full record.
 
 ### Fixed
 
+- **Revoking an API key from the AI assistant or an MCP client now actually
+  revokes it.** The dashboard and CLI evicted the key from the authentication
+  cache; the MCP tool deleted the database row and stopped there. Because
+  `/mcp` and `/fn/` read credentials straight from the database, the key
+  stopped working on exactly the surface it was revoked from — while it kept
+  full access to the REST API, including minting new keys, reading secrets and
+  downloading a backup, until the server restarted. The revocation looked
+  confirmed and was not. **If you have revoked a key through the AI sidebar or
+  an MCP client, restart Orva** — that key may still be live. Keys revoked from
+  the dashboard or `orva keys revoke` were never affected.
+
+- **Logging out, revoking a device, and changing your password now take effect
+  immediately.** All three deleted the session row but left the session in the
+  authentication cache, so the cookie kept working for up to 30 seconds
+  afterwards — with no permission check, meaning full operator access on every
+  API route. For a password change that is the entire window the change exists
+  to close.
+
+- **A cached API key is now re-checked against the database at least every 30
+  seconds.** The cache had no expiry, so anything that revoked a key without
+  evicting it stayed stale until the process restarted. Sessions were already
+  re-checked on this interval; keys now match. This is the backstop, not the
+  fix — every revocation path evicts directly.
+
 - **`docker compose up -d` no longer locks you out of the dashboard on a LAN
   address.** The shipped `docker-compose.yml` set `ORVA_SECURE_COOKIES=true`
   while publishing plain HTTP on port 3000. A browser will not store a `Secure`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,12 +42,15 @@ the commit messages; `git log v2026.08.05..HEAD` is the full record.
   an MCP client, restart Orva** — that key may still be live. Keys revoked from
   the dashboard or `orva keys revoke` were never affected.
 
-- **Logging out, revoking a device, and changing your password now take effect
-  immediately.** All three deleted the session row but left the session in the
-  authentication cache, so the cookie kept working for up to 30 seconds
-  afterwards — with no permission check, meaning full operator access on every
-  API route. For a password change that is the entire window the change exists
-  to close.
+- **Logging out, revoking a device, refreshing a session, and changing your
+  password now take effect at once.** All four deleted the session row but left
+  the session in the authentication cache, so the cookie kept working for up to
+  30 seconds afterwards — with no permission check, meaning full operator
+  access on every API route. For a password change that is the entire window
+  the change exists to close. (A request already mid-flight through the
+  authentication check when you revoke can still finish and re-cache; that
+  window is now bounded by the 30-second re-check below rather than by a
+  restart.)
 
 - **A cached API key is now re-checked against the database at least every 30
   seconds.** The cache had no expiry, so anything that revoked a key without

--- a/backend/internal/database/user_sessions_test.go
+++ b/backend/internal/database/user_sessions_test.go
@@ -30,8 +30,20 @@ func TestDeleteUserSessionsExcept(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if revoked != 2 {
-		t.Errorf("revoked = %d, want 2", revoked)
+	if len(revoked) != 2 {
+		t.Fatalf("revoked = %d sessions, want 2", len(revoked))
+	}
+	// The tokens themselves, not just a count: the caller has to evict each
+	// one from the auth middleware's memo, and a count cannot do that.
+	want := map[string]bool{tokens[1]: true, tokens[2]: true}
+	for _, tok := range revoked {
+		if !want[tok] {
+			t.Errorf("revoked an unexpected token %q", tok)
+		}
+		delete(want, tok)
+	}
+	for tok := range want {
+		t.Errorf("token %q was revoked but not returned, so nothing can evict its memo", tok)
 	}
 
 	remaining, err := db.ListSessionsForUser(user.ID)

--- a/backend/internal/database/users.go
+++ b/backend/internal/database/users.go
@@ -188,7 +188,11 @@ func (db *Database) DeleteSessionByPrefix(prefix string, userID int64) (string, 
 		}
 		matches = append(matches, t)
 	}
+	err = rows.Err()
 	rows.Close()
+	if err != nil {
+		return "", err
+	}
 	switch len(matches) {
 	case 0:
 		return "", sql.ErrNoRows
@@ -222,23 +226,27 @@ func (db *Database) DeleteSession(token string) error {
 // middleware memoises validated sessions by token, so a stolen cookie goes on
 // working until its memo ages out unless the caller evicts these.
 func (db *Database) DeleteUserSessionsExcept(userID int64, keepToken string) ([]string, error) {
-	rows, err := db.read.Query(
-		"SELECT token FROM sessions WHERE user_id = ? AND token != ?", userID, keepToken)
+	// DELETE ... RETURNING rather than SELECT-then-DELETE: the read pool and
+	// the write pool are different connections, so a session created between
+	// the two statements would be deleted without ever being returned, and its
+	// memo would then survive the revocation this call exists to perform.
+	rows, err := db.write.Query(
+		"DELETE FROM sessions WHERE user_id = ? AND token != ? RETURNING token", userID, keepToken)
 	if err != nil {
 		return nil, err
 	}
+	defer rows.Close()
 	var revoked []string
 	for rows.Next() {
 		var t string
 		if err := rows.Scan(&t); err != nil {
-			rows.Close()
 			return nil, err
 		}
 		revoked = append(revoked, t)
 	}
-	rows.Close()
-	if _, err := db.write.Exec(
-		"DELETE FROM sessions WHERE user_id = ? AND token != ?", userID, keepToken); err != nil {
+	// A scan that stops on a driver error would otherwise hand back a partial
+	// list of a complete delete -- some sessions revoked, their memos kept.
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return revoked, nil

--- a/backend/internal/database/users.go
+++ b/backend/internal/database/users.go
@@ -169,31 +169,36 @@ func (db *Database) ListSessionsForUser(userID int64) ([]*Session, error) {
 // session belonging to a different user). Returns ErrAmbiguousPrefix
 // if more than one row matches — should never happen with 16 hex
 // chars (~64 bits of entropy) but the loop is cheap insurance.
-func (db *Database) DeleteSessionByPrefix(prefix string, userID int64) error {
+// It returns the full token it deleted. Deleting the row is only half of a
+// revocation -- the auth middleware memoises validated sessions by token, so
+// the caller has to evict that entry too, and it cannot do so from a prefix.
+func (db *Database) DeleteSessionByPrefix(prefix string, userID int64) (string, error) {
 	rows, err := db.read.Query(`
 		SELECT token FROM sessions
 		WHERE user_id = ? AND token LIKE ? || '%'`, userID, prefix)
 	if err != nil {
-		return err
+		return "", err
 	}
 	var matches []string
 	for rows.Next() {
 		var t string
 		if err := rows.Scan(&t); err != nil {
 			rows.Close()
-			return err
+			return "", err
 		}
 		matches = append(matches, t)
 	}
 	rows.Close()
 	switch len(matches) {
 	case 0:
-		return sql.ErrNoRows
+		return "", sql.ErrNoRows
 	case 1:
-		_, err := db.write.Exec("DELETE FROM sessions WHERE token = ?", matches[0])
-		return err
+		if _, err := db.write.Exec("DELETE FROM sessions WHERE token = ?", matches[0]); err != nil {
+			return "", err
+		}
+		return matches[0], nil
 	default:
-		return ErrAmbiguousSessionPrefix
+		return "", ErrAmbiguousSessionPrefix
 	}
 }
 
@@ -210,16 +215,33 @@ func (db *Database) DeleteSession(token string) error {
 // DeleteUserSessionsExcept revokes every session for the user except the one
 // identified by keepToken (pass "" to revoke all). Used after a password change
 // so a compromised credential's stolen sessions are invalidated immediately
-// while the operator performing the change stays logged in. Returns the number
-// of sessions revoked.
-func (db *Database) DeleteUserSessionsExcept(userID int64, keepToken string) (int64, error) {
-	res, err := db.write.Exec(
-		"DELETE FROM sessions WHERE user_id = ? AND token != ?", userID, keepToken)
+// while the operator performing the change stays logged in.
+//
+// Returns the tokens it revoked. "Immediately" is the whole point of this
+// call, and deleting the rows does not achieve it on its own: the auth
+// middleware memoises validated sessions by token, so a stolen cookie goes on
+// working until its memo ages out unless the caller evicts these.
+func (db *Database) DeleteUserSessionsExcept(userID int64, keepToken string) ([]string, error) {
+	rows, err := db.read.Query(
+		"SELECT token FROM sessions WHERE user_id = ? AND token != ?", userID, keepToken)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	n, _ := res.RowsAffected()
-	return n, nil
+	var revoked []string
+	for rows.Next() {
+		var t string
+		if err := rows.Scan(&t); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		revoked = append(revoked, t)
+	}
+	rows.Close()
+	if _, err := db.write.Exec(
+		"DELETE FROM sessions WHERE user_id = ? AND token != ?", userID, keepToken); err != nil {
+		return nil, err
+	}
+	return revoked, nil
 }
 
 // ErrWrongPassword is returned by UpdateUserPassword when the supplied

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -67,6 +67,14 @@ type Deps struct {
 	// AllowedOrigins is ORVA_CORS_ORIGINS. Empty, or ["*"], means any origin —
 	// the default. Narrowing it also narrows /mcp.
 	AllowedOrigins []string
+
+	// InvalidateKey evicts a key (by its hash) from the auth middleware's
+	// in-memory cache, so revoking one here stops it authenticating on
+	// /api/v1/* immediately rather than at the next process restart. It is
+	// the same callback the REST key handler holds; both must have it,
+	// because a revocation only half the surfaces honour is worse than none
+	// at all -- it reports success. Optional; nil is a no-op.
+	InvalidateKey func(keyHash string)
 }
 
 // operatorServerCache holds one immutable server per permission surface. Orva

--- a/backend/internal/mcp/server.go
+++ b/backend/internal/mcp/server.go
@@ -70,7 +70,7 @@ type Deps struct {
 
 	// InvalidateKey evicts a key (by its hash) from the auth middleware's
 	// in-memory cache, so revoking one here stops it authenticating on
-	// /api/v1/* immediately rather than at the next process restart. It is
+	// /api/v1/* at once rather than whenever its entry ages out. It is
 	// the same callback the REST key handler holds; both must have it,
 	// because a revocation only half the surfaces honour is worse than none
 	// at all -- it reports success. Optional; nil is a no-op.

--- a/backend/internal/mcp/tools_keys.go
+++ b/backend/internal/mcp/tools_keys.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -159,27 +160,33 @@ func registerKeyTools(rc *regCtx) {
 				return nil, DeletedOutput{}, errors.New("delete refused: pass confirm=true")
 			}
 			// Read the hash before the row goes away -- it is what the auth
-			// cache is keyed on, and that cache has no TTL. Without this the
-			// deleted key goes on authenticating every /api/v1/* request for
-			// the life of the process. /mcp reads the database directly and
+			// cache is keyed on. Without this the deleted key goes on
+			// authenticating /api/v1/* requests until its entry ages out,
+			// which is a backstop and not a revocation. /mcp reads the
+			// database directly and
 			// so rejects it at once, which makes the gap worse rather than
 			// better: the key looks revoked from the AI sidebar the operator
 			// revoked it in, and still opens the REST API.
 			var keyHash string
-			if k, err := deps.DB.GetAPIKeyByID(in.KeyID); err == nil && k != nil {
+			k, lookupErr := deps.DB.GetAPIKeyByID(in.KeyID)
+			if lookupErr == nil && k != nil {
 				keyHash = k.KeyHash
 			}
 			if err := deps.DB.DeleteAPIKey(in.KeyID); err != nil {
 				return nil, DeletedOutput{}, err
 			}
-			if keyHash == "" {
-				// The row was gone or unreadable before we deleted it, so
-				// there is no hash to evict. Say so rather than reporting a
-				// revocation that may not have taken effect.
-				slog.Warn("api key deleted without evicting the auth cache: hash unavailable",
-					"key_id", in.KeyID)
-			} else if deps.InvalidateKey != nil {
+			// An id that never existed is not worth a warning -- nothing was
+			// cached and nothing is at risk. A hash we could not read, or an
+			// invalidator that was never wired, both are.
+			switch {
+			case keyHash != "" && deps.InvalidateKey != nil:
 				deps.InvalidateKey(keyHash)
+			case keyHash != "":
+				slog.Warn("api key deleted but no cache invalidator is wired: it keeps authenticating until its entry ages out",
+					"key_id", in.KeyID)
+			case lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows):
+				slog.Warn("api key deleted without evicting the auth cache: could not read its hash first",
+					"key_id", in.KeyID, "err", lookupErr)
 			}
 			return nil, DeletedOutput{DeletedID: in.KeyID}, nil
 		},

--- a/backend/internal/mcp/tools_keys.go
+++ b/backend/internal/mcp/tools_keys.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -157,8 +158,28 @@ func registerKeyTools(rc *regCtx) {
 			if !in.Confirm {
 				return nil, DeletedOutput{}, errors.New("delete refused: pass confirm=true")
 			}
+			// Read the hash before the row goes away -- it is what the auth
+			// cache is keyed on, and that cache has no TTL. Without this the
+			// deleted key goes on authenticating every /api/v1/* request for
+			// the life of the process. /mcp reads the database directly and
+			// so rejects it at once, which makes the gap worse rather than
+			// better: the key looks revoked from the AI sidebar the operator
+			// revoked it in, and still opens the REST API.
+			var keyHash string
+			if k, err := deps.DB.GetAPIKeyByID(in.KeyID); err == nil && k != nil {
+				keyHash = k.KeyHash
+			}
 			if err := deps.DB.DeleteAPIKey(in.KeyID); err != nil {
 				return nil, DeletedOutput{}, err
+			}
+			if keyHash == "" {
+				// The row was gone or unreadable before we deleted it, so
+				// there is no hash to evict. Say so rather than reporting a
+				// revocation that may not have taken effect.
+				slog.Warn("api key deleted without evicting the auth cache: hash unavailable",
+					"key_id", in.KeyID)
+			} else if deps.InvalidateKey != nil {
+				deps.InvalidateKey(keyHash)
 			}
 			return nil, DeletedOutput{DeletedID: in.KeyID}, nil
 		},

--- a/backend/internal/mcp/tools_keys_test.go
+++ b/backend/internal/mcp/tools_keys_test.go
@@ -22,8 +22,9 @@ func keysTestDB(t *testing.T) *database.Database {
 	return db
 }
 
-// The auth middleware caches API keys by hash in a sync.Map with no TTL, so a
-// revoked key is only actually revoked once something evicts it. The REST
+// The auth middleware memoises API keys by hash, so a revoked key is only
+// actually revoked once something evicts that memo; the entry's TTL bounds the
+// damage of forgetting but does not do the job. The REST
 // handler has always done that. This tool did not, so a key revoked through
 // the AI sidebar or an MCP client went on authenticating every /api/v1/*
 // request for the life of the process.

--- a/backend/internal/mcp/tools_keys_test.go
+++ b/backend/internal/mcp/tools_keys_test.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/Harsh-2002/Orva/backend/internal/database"
+)
+
+func keysTestDB(t *testing.T) *database.Database {
+	t.Helper()
+	db, err := database.New(filepath.Join(t.TempDir(), "mcp-keys.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+// The auth middleware caches API keys by hash in a sync.Map with no TTL, so a
+// revoked key is only actually revoked once something evicts it. The REST
+// handler has always done that. This tool did not, so a key revoked through
+// the AI sidebar or an MCP client went on authenticating every /api/v1/*
+// request for the life of the process.
+//
+// The asymmetry is what made it dangerous rather than merely wrong: /mcp
+// resolves credentials straight from the database, so the key stopped working
+// on exactly the surface the operator revoked it from, and kept working
+// everywhere else. The tool's own description promises "Active sessions using
+// that key fail their next request with 401".
+func TestDeleteAPIKeyToolEvictsTheAuthCache(t *testing.T) {
+	db := keysTestDB(t)
+
+	const keyID, keyHash = "key_revokeme", "hash-of-the-revoked-key"
+	if err := db.InsertAPIKey(&database.APIKey{
+		ID: keyID, KeyHash: keyHash, Prefix: "orva_rev", Name: "to be revoked",
+		Permissions: `["invoke","read","write","admin"]`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var evicted []string
+	reg := BuildAgentRegistry(Deps{
+		DB:            db,
+		InvalidateKey: func(h string) { evicted = append(evicted, h) },
+	}, allPerms())
+
+	tool := reg.Get("delete_api_key")
+	if tool == nil {
+		t.Fatal("delete_api_key is not registered for an admin principal")
+	}
+	if _, err := reg.Dispatch(context.Background(), "delete_api_key",
+		json.RawMessage(`{"key_id":"`+keyID+`","confirm":true}`)); err != nil {
+		t.Fatalf("delete_api_key: %v", err)
+	}
+
+	// The row is gone...
+	if k, err := db.GetAPIKeyByID(keyID); err == nil && k != nil {
+		t.Error("the key row survived the delete")
+	}
+	// ...and so is the cache entry that would have kept it working.
+	if len(evicted) != 1 || evicted[0] != keyHash {
+		t.Errorf("evicted = %v, want exactly [%q]: without this the revoked key keeps authenticating on /api/v1/* until the process restarts",
+			evicted, keyHash)
+	}
+}
+
+// A refused delete must not evict anything: the key is still valid, and
+// dropping it from the cache would silently cost every holder a database
+// round-trip on their next request for no reason.
+func TestDeleteAPIKeyToolEvictsNothingWhenItRefuses(t *testing.T) {
+	db := keysTestDB(t)
+	const keyID, keyHash = "key_keepme", "hash-of-the-surviving-key"
+	if err := db.InsertAPIKey(&database.APIKey{
+		ID: keyID, KeyHash: keyHash, Prefix: "orva_keep", Name: "kept",
+		Permissions: `["read"]`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var evicted []string
+	reg := BuildAgentRegistry(Deps{
+		DB:            db,
+		InvalidateKey: func(h string) { evicted = append(evicted, h) },
+	}, allPerms())
+
+	if _, err := reg.Dispatch(context.Background(), "delete_api_key",
+		json.RawMessage(`{"key_id":"`+keyID+`"}`)); err == nil {
+		t.Fatal("delete without confirm=true was accepted")
+	}
+	if len(evicted) != 0 {
+		t.Errorf("evicted %v on a refused delete", evicted)
+	}
+	if k, err := db.GetAPIKeyByID(keyID); err != nil || k == nil {
+		t.Error("a refused delete removed the row anyway")
+	}
+}
+
+// Deps.InvalidateKey is optional, and the tool must not panic without it --
+// several tests and the schema-only registration path build Deps bare.
+func TestDeleteAPIKeyToolToleratesNoInvalidator(t *testing.T) {
+	db := keysTestDB(t)
+	if err := db.InsertAPIKey(&database.APIKey{
+		ID: "key_nocb", KeyHash: "hash-nocb", Prefix: "orva_nocb", Name: "n",
+		Permissions: `["read"]`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	reg := BuildAgentRegistry(Deps{DB: db}, allPerms())
+	if _, err := reg.Dispatch(context.Background(), "delete_api_key",
+		json.RawMessage(`{"key_id":"key_nocb","confirm":true}`)); err != nil {
+		t.Fatalf("delete_api_key with a nil InvalidateKey: %v", err)
+	}
+}

--- a/backend/internal/server/handlers/auth.go
+++ b/backend/internal/server/handlers/auth.go
@@ -29,11 +29,35 @@ type AuthHandler struct {
 	SecureCookies     bool // set when Orva is behind an HTTPS reverse proxy
 	SessionMaxAgeSecs int  // 0 → default 7 days
 
+	// InvalidateSession evicts a session token from the auth middleware's
+	// memo. Deleting the sessions row is only half a revocation: the
+	// middleware answers from that memo for up to sessionCacheTTL, and the
+	// session branch performs no permission check, so the window is full
+	// operator access on every /api/v1/* route. Optional; nil is a no-op.
+	InvalidateSession func(token string)
+
 	// loginLimiter throttles login attempts per client IP. Lazily built so
 	// existing tests that construct AuthHandler with zero-value fields keep
 	// working (mirrors InvokeHandler's rateLimiter pattern).
 	loginLimiterOnce sync.Once
 	loginLimiter     *rateLimiter
+}
+
+// revokeSession deletes a session and evicts its memo. Every path that ends a
+// session goes through here so none of them can do only the first half.
+func (h *AuthHandler) revokeSession(token string) {
+	if token == "" {
+		return
+	}
+	_ = h.DB.DeleteSession(token)
+	h.forgetSession(token)
+}
+
+// forgetSession evicts a token whose row some other call already removed.
+func (h *AuthHandler) forgetSession(token string) {
+	if h.InvalidateSession != nil && token != "" {
+		h.InvalidateSession(token)
+	}
 }
 
 func (h *AuthHandler) sessionMaxAge() int {
@@ -324,7 +348,7 @@ func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Best-effort revoke of the old token.
-	_ = h.DB.DeleteSession(cookie.Value)
+	h.revokeSession(cookie.Value)
 
 	h.setSessionCookie(w, r, newSession.Token, h.sessionMaxAge())
 	respond.JSON(w, http.StatusOK, map[string]any{
@@ -382,12 +406,18 @@ func (h *AuthHandler) ChangePassword(w http.ResponseWriter, r *http.Request) {
 	// (cookie.Value) is kept so the operator making the change stays logged in.
 	// Best-effort: a revocation failure must not fail the (already-committed)
 	// password change.
-	if _, err := h.DB.DeleteUserSessionsExcept(user.ID, cookie.Value); err != nil {
+	revoked, err := h.DB.DeleteUserSessionsExcept(user.ID, cookie.Value)
+	if err != nil {
 		respond.JSON(w, http.StatusOK, map[string]string{
 			"status":  "password_changed",
 			"warning": "password updated but other sessions could not be revoked",
 		})
 		return
+	}
+	// Evicting these is what makes the revocation immediate, which is the
+	// entire point of doing it on a password change.
+	for _, token := range revoked {
+		h.forgetSession(token)
 	}
 
 	respond.JSON(w, http.StatusOK, map[string]string{"status": "password_changed"})
@@ -468,7 +498,8 @@ func (h *AuthHandler) RevokeSession(w http.ResponseWriter, r *http.Request) {
 			"refusing to revoke the calling session — use POST /auth/logout instead", "")
 		return
 	}
-	if err := h.DB.DeleteSessionByPrefix(prefix, user.ID); err != nil {
+	revokedToken, err := h.DB.DeleteSessionByPrefix(prefix, user.ID)
+	if err != nil {
 		if err == database.ErrAmbiguousSessionPrefix {
 			respond.Error(w, http.StatusBadRequest, "AMBIGUOUS_PREFIX", "prefix matches multiple sessions", "")
 			return
@@ -477,6 +508,7 @@ func (h *AuthHandler) RevokeSession(w http.ResponseWriter, r *http.Request) {
 		respond.Error(w, http.StatusNotFound, "NOT_FOUND", "no such session", "")
 		return
 	}
+	h.forgetSession(revokedToken)
 	respond.JSON(w, http.StatusOK, map[string]any{"ok": true})
 }
 
@@ -484,7 +516,7 @@ func (h *AuthHandler) RevokeSession(w http.ResponseWriter, r *http.Request) {
 func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	cookie, err := r.Cookie("session_token")
 	if err == nil {
-		h.DB.DeleteSession(cookie.Value)
+		h.revokeSession(cookie.Value)
 	}
 
 	// Cleared through the same helper so the attributes match the cookie

--- a/backend/internal/server/handlers/keys.go
+++ b/backend/internal/server/handlers/keys.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -152,7 +153,8 @@ func (h *KeyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Capture the key's hash BEFORE deleting so we can evict it from the auth
-	// cache — otherwise a revoked key keeps working until process restart.
+	// cache — otherwise a revoked key keeps working until its cache entry
+	// ages out.
 	var keyHash string
 	if k, err := h.DB.GetAPIKeyByID(keyID); err == nil && k != nil {
 		keyHash = k.KeyHash
@@ -163,7 +165,13 @@ func (h *KeyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if h.InvalidateKey != nil && keyHash != "" {
+	if keyHash == "" {
+		// No hash means no eviction, and this still answers 200. Say so:
+		// a revocation that reports success without taking full effect is
+		// the one thing an operator must not have to guess about.
+		slog.Warn("api key deleted without evicting the auth cache: hash unavailable",
+			"key_id", keyID)
+	} else if h.InvalidateKey != nil {
 		h.InvalidateKey(keyHash)
 	}
 

--- a/backend/internal/server/handlers/keys.go
+++ b/backend/internal/server/handlers/keys.go
@@ -3,8 +3,10 @@ package handlers
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -156,7 +158,8 @@ func (h *KeyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 	// cache — otherwise a revoked key keeps working until its cache entry
 	// ages out.
 	var keyHash string
-	if k, err := h.DB.GetAPIKeyByID(keyID); err == nil && k != nil {
+	k, lookupErr := h.DB.GetAPIKeyByID(keyID)
+	if lookupErr == nil && k != nil {
 		keyHash = k.KeyHash
 	}
 
@@ -165,17 +168,33 @@ func (h *KeyHandler) Delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if keyHash == "" {
-		// No hash means no eviction, and this still answers 200. Say so:
-		// a revocation that reports success without taking full effect is
-		// the one thing an operator must not have to guess about.
-		slog.Warn("api key deleted without evicting the auth cache: hash unavailable",
-			"key_id", keyID)
-	} else if h.InvalidateKey != nil {
-		h.InvalidateKey(keyHash)
-	}
+	warnIfNotEvicted(keyID, keyHash, lookupErr, h.InvalidateKey)
 
 	respond.JSON(w, http.StatusOK, map[string]string{"status": "deleted", "id": keyID})
+}
+
+// warnIfNotEvicted reports the cases where a delete answers success without
+// the cache eviction that makes it a revocation.
+//
+// The two are told apart deliberately. A lookup that found no row means the id
+// never existed: nothing was cached, nothing is at risk, and warning about it
+// would cry wolf on the commonest case there is -- a typo, a stale id, a
+// double delete, an agent guessing. A lookup that failed for any other reason
+// means a real key may have been deleted with its entry left behind.
+//
+// The third case is the one that produced this whole change: a hash in hand
+// and no invalidator wired. That used to pass silently.
+func warnIfNotEvicted(keyID, keyHash string, lookupErr error, invalidate func(string)) {
+	switch {
+	case keyHash != "" && invalidate != nil:
+		invalidate(keyHash)
+	case keyHash != "":
+		slog.Warn("api key deleted but no cache invalidator is wired: it keeps authenticating until its entry ages out",
+			"key_id", keyID)
+	case lookupErr != nil && !errors.Is(lookupErr, sql.ErrNoRows):
+		slog.Warn("api key deleted without evicting the auth cache: could not read its hash first",
+			"key_id", keyID, "err", lookupErr)
+	}
 }
 
 // extractKeyID extracts the key ID from path /api/v1/keys/{key_id}.

--- a/backend/internal/server/middleware_auth.go
+++ b/backend/internal/server/middleware_auth.go
@@ -16,7 +16,12 @@ import (
 
 // sessionCacheEntry is a short-TTL memo of a successful session lookup so
 // the UI dashboard doesn't hammer SQLite with GetSessionUser on every poll.
-// TTL is short enough that logout propagates without explicit invalidation.
+// The TTL bounds a stale entry; it does NOT make eviction unnecessary. An
+// earlier version of this comment claimed it did, and on the strength of that
+// sessionCache was declared inside this function where no handler could reach
+// it -- so logout, revoke-device and the password-change purge each deleted a
+// row and left the cookie working. The Router owns the map now and every one
+// of those paths evicts.
 type sessionCacheEntry struct {
 	validUntil time.Time // re-check DB after this
 }

--- a/backend/internal/server/middleware_auth.go
+++ b/backend/internal/server/middleware_auth.go
@@ -23,13 +23,28 @@ type sessionCacheEntry struct {
 
 const sessionCacheTTL = 30 * time.Second
 
+// keyCacheEntry memos a successful API-key lookup, on the same short TTL as
+// sessionCacheEntry above and for the same reason -- plus one more.
+//
+// Evicting a revoked key is a duty each delete call site has to remember, and
+// the MCP tool forgot for long enough to ship: a key revoked from the AI
+// sidebar went on authenticating every /api/v1/* request until the process
+// restarted, because nothing here ever dropped it. Both call sites evict now,
+// but the next one added inherits the same trap. A TTL is what makes that a
+// thirty-second bug rather than an unbounded one.
+type keyCacheEntry struct {
+	key        *database.APIKey
+	validUntil time.Time
+}
+
+const keyCacheTTL = 30 * time.Second
+
 // authMiddleware validates API key authentication and permission checks.
 // Uses an in-memory cache to avoid hitting SQLite on every request. keyCache is
-// owned by the Router and shared so the keys handler can evict an entry the
-// instant a key is deleted — otherwise a revoked key would keep authenticating
-// until process restart (it is only otherwise dropped on expiry).
-func authMiddleware(db *database.Database, keyCache *sync.Map, sdkAuth *sdkauth.Authenticator, next http.Handler) http.Handler {
-	var sessionCache sync.Map // token -> sessionCacheEntry
+// owned by the Router and shared so every path that revokes a key can evict its
+// entry immediately; the TTL on those entries is the backstop for the one that
+// forgets.
+func authMiddleware(db *database.Database, keyCache, sessionCache *sync.Map, sdkAuth *sdkauth.Authenticator, next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip auth on public endpoints: health, UI, root redirect, auth routes.
@@ -146,9 +161,15 @@ func authMiddleware(db *database.Database, keyCache *sync.Map, sdkAuth *sdkauth.
 
 		// Check in-memory cache first.
 		var key *database.APIKey
+		keyNow := time.Now()
 		if cached, ok := keyCache.Load(keyHash); ok {
-			key = cached.(*database.APIKey)
-		} else {
+			if entry := cached.(keyCacheEntry); keyNow.Before(entry.validUntil) {
+				key = entry.key
+			} else {
+				keyCache.Delete(keyHash)
+			}
+		}
+		if key == nil {
 			var err error
 			key, err = db.GetAPIKeyByHash(keyHash)
 			if err != nil {
@@ -159,7 +180,7 @@ func authMiddleware(db *database.Database, keyCache *sync.Map, sdkAuth *sdkauth.
 				}
 				return
 			}
-			keyCache.Store(keyHash, key)
+			keyCache.Store(keyHash, keyCacheEntry{key: key, validUntil: keyNow.Add(keyCacheTTL)})
 		}
 
 		// Check expiry.

--- a/backend/internal/server/revocation_test.go
+++ b/backend/internal/server/revocation_test.go
@@ -18,8 +18,8 @@ import (
 // Revoking an API key through the AI assistant or an MCP client left it
 // working on the whole REST API.
 //
-// authMiddleware caches keys by hash in a sync.Map with no TTL, so a key stops
-// authenticating only once something evicts it. The REST delete handler always
+// authMiddleware memoises keys by hash, so a key stops authenticating only
+// once something evicts that memo. The REST delete handler always
 // did that; the MCP tool called DeleteAPIKey and nothing else, because the
 // eviction was a second copy of the idea rather than the same one. /mcp
 // resolves credentials from the database directly, so the key died on exactly
@@ -144,12 +144,23 @@ func TestAStaleKeyCacheEntryExpiresOnItsOwn(t *testing.T) {
 			"if this fails the test is no longer measuring the TTL", got)
 	}
 
-	// Age the entry past its TTL rather than sleeping for it.
+	// The stamp has to be a real bound, not merely present. An earlier version
+	// of this test only rewound validUntil by hand, which exercised the
+	// comparison and nothing else -- it passed with keyCacheTTL set to eleven
+	// years, while the changelog promised thirty seconds.
+	if keyCacheTTL > time.Minute {
+		t.Fatalf("keyCacheTTL = %s: the backstop is only a backstop if it is short", keyCacheTTL)
+	}
 	cached, ok := r.keyCache.Load(orphanHash)
 	if !ok {
 		t.Fatal("no cache entry to age")
 	}
 	entry := cached.(keyCacheEntry)
+	if d := time.Until(entry.validUntil); d > keyCacheTTL {
+		t.Errorf("entry is valid for %s, longer than keyCacheTTL (%s)", d, keyCacheTTL)
+	}
+
+	// Age it past the stamp rather than sleeping for it.
 	entry.validUntil = time.Now().Add(-time.Second)
 	r.keyCache.Store(orphanHash, entry)
 
@@ -168,6 +179,10 @@ func TestAStaleKeyCacheEntryExpiresOnItsOwn(t *testing.T) {
 // own logout is full operator access on every /api/v1/* route until the memo
 // ages out. For the password-change purge that is precisely the window the
 // purge exists to close.
+// sessionPrefixLenForTest mirrors handlers.sessionTokenPrefixLen, which is
+// unexported. The revoke-device route addresses a session by that prefix.
+const sessionPrefixLenForTest = 16
+
 func TestEndingASessionStopsTheCookieImmediately(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -202,6 +217,37 @@ func TestEndingASessionStopsTheCookieImmediately(t *testing.T) {
 				r.ServeHTTP(w, req)
 				if w.Code != http.StatusOK {
 					t.Fatalf("change-password returned %d: %s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			name: "revoke a device",
+			end: func(t *testing.T, r *Router, token string, userID int64) {
+				// The handler refuses to revoke its own caller, so a second
+				// session does the revoking.
+				caller, err := r.db.CreateSession(userID, time.Hour)
+				if err != nil {
+					t.Fatal(err)
+				}
+				prefix := token[:sessionPrefixLenForTest]
+				req := httptest.NewRequest(http.MethodDelete, "/api/v1/auth/sessions/"+prefix, nil)
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: caller.Token})
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("revoke session returned %d: %s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			name: "refresh revokes the token it replaces",
+			end: func(t *testing.T, r *Router, token string, _ int64) {
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/refresh", nil)
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: token})
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("refresh returned %d: %s", w.Code, w.Body.String())
 				}
 			},
 		},

--- a/backend/internal/server/revocation_test.go
+++ b/backend/internal/server/revocation_test.go
@@ -1,0 +1,249 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Harsh-2002/Orva/backend/internal/database"
+
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// Revoking an API key through the AI assistant or an MCP client left it
+// working on the whole REST API.
+//
+// authMiddleware caches keys by hash in a sync.Map with no TTL, so a key stops
+// authenticating only once something evicts it. The REST delete handler always
+// did that; the MCP tool called DeleteAPIKey and nothing else, because the
+// eviction was a second copy of the idea rather than the same one. /mcp
+// resolves credentials from the database directly, so the key died on exactly
+// the surface the operator revoked it from and lived on every other one --
+// until the process restarted.
+//
+// This drives the router's real /mcp route, so it covers the wiring as well as
+// the tool: a Deps built without the callback fails here even though the tool
+// itself is correct.
+func TestKeyRevokedThroughMCPStopsWorkingOnTheRESTAPI(t *testing.T) {
+	tc := newTestServer(t)
+	r := tc.srv.router
+
+	const victim = "orva_victim_key_that_gets_revoked_0123456789"
+	sum := sha256.Sum256([]byte(victim))
+	victimHash := hex.EncodeToString(sum[:])
+	if err := r.db.InsertAPIKey(&database.APIKey{
+		ID: "key_victim01", KeyHash: victimHash, Prefix: "orva_vic",
+		Name: "revoked-via-mcp", Permissions: `["invoke","read","write","admin"]`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/functions", nil)
+		req.Header.Set("X-Orva-API-Key", victim)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// Warm the cache. Without this the test passes for the wrong reason: the
+	// middleware would miss, fall through to the database, find nothing and
+	// 401 whether or not anything was evicted.
+	if got := probe(); got == http.StatusUnauthorized {
+		t.Fatalf("the key did not authenticate before revocation (got %d)", got)
+	}
+	if _, cached := r.keyCache.Load(victimHash); !cached {
+		t.Fatal("the key never entered the auth cache, so an eviction cannot be observed here")
+	}
+
+	// Revoke it the way the AI sidebar and any MCP client do.
+	// The 2026-07-28 transport carries the handshake in params._meta on every
+	// request rather than in a session, so a bare tools/call is rejected as
+	// invalid params before it reaches the tool.
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+		"params": map[string]any{
+			"name":      "delete_api_key",
+			"arguments": map[string]any{"key_id": "key_victim01", "confirm": true},
+			"_meta": map[string]any{
+				mcpsdk.MetaKeyProtocolVersion:    "2026-07-28",
+				mcpsdk.MetaKeyClientCapabilities: map[string]any{},
+				mcpsdk.MetaKeyClientInfo:         map[string]any{"name": "orva-revocation-test", "version": "1"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(string(body)))
+	req.Host = "orva.test"
+	req.Header.Set("Authorization", "Bearer "+tc.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", "tools/call")
+	req.Header.Set("Mcp-Name", "delete_api_key")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("tools/call delete_api_key returned %d: %s", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), `"isError":true`) {
+		t.Fatalf("delete_api_key reported an error: %s", w.Body.String())
+	}
+
+	if got := probe(); got != http.StatusUnauthorized {
+		t.Errorf("a revoked key still authenticated: GET /api/v1/functions returned %d, want 401", got)
+	}
+	if _, cached := r.keyCache.Load(victimHash); cached {
+		t.Error("the revoked key is still in the auth cache")
+	}
+}
+
+// The TTL is the backstop for a revocation path that forgets to evict. Both
+// current ones remember, so this simulates the one that does not: delete the
+// row underneath the cache and leave the entry in place, exactly as an
+// un-wired call site would.
+func TestAStaleKeyCacheEntryExpiresOnItsOwn(t *testing.T) {
+	tc := newTestServer(t)
+	r := tc.srv.router
+
+	const orphan = "orva_orphan_key_never_evicted_0123456789abc"
+	sum := sha256.Sum256([]byte(orphan))
+	orphanHash := hex.EncodeToString(sum[:])
+	if err := r.db.InsertAPIKey(&database.APIKey{
+		ID: "key_orphan01", KeyHash: orphanHash, Prefix: "orva_orp",
+		Name: "orphaned", Permissions: `["invoke","read","write","admin"]`,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	probe := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/functions", nil)
+		req.Header.Set("X-Orva-API-Key", orphan)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if got := probe(); got == http.StatusUnauthorized {
+		t.Fatalf("the key did not authenticate before revocation (got %d)", got)
+	}
+
+	// Revoke at the database only -- no eviction, the bug this guards against.
+	if err := r.db.DeleteAPIKey("key_orphan01"); err != nil {
+		t.Fatal(err)
+	}
+	if got := probe(); got != http.StatusOK {
+		t.Fatalf("expected the stale cache entry to still authenticate (got %d); "+
+			"if this fails the test is no longer measuring the TTL", got)
+	}
+
+	// Age the entry past its TTL rather than sleeping for it.
+	cached, ok := r.keyCache.Load(orphanHash)
+	if !ok {
+		t.Fatal("no cache entry to age")
+	}
+	entry := cached.(keyCacheEntry)
+	entry.validUntil = time.Now().Add(-time.Second)
+	r.keyCache.Store(orphanHash, entry)
+
+	if got := probe(); got != http.StatusUnauthorized {
+		t.Errorf("a stale entry past its TTL still authenticated: got %d, want 401", got)
+	}
+}
+
+// Ending a session has the same two halves as revoking a key: delete the row,
+// and evict the memo the auth middleware answers from. Only the first half was
+// ever done, and sessionCache was declared inside authMiddleware so no handler
+// could have done the second.
+//
+// The window mattered more here than for keys: the session branch grants
+// access without consulting permissions at all, so a cookie that survives its
+// own logout is full operator access on every /api/v1/* route until the memo
+// ages out. For the password-change purge that is precisely the window the
+// purge exists to close.
+func TestEndingASessionStopsTheCookieImmediately(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		// end revokes the session under test, given the router and the cookie.
+		end func(t *testing.T, r *Router, token string, userID int64)
+	}{
+		{
+			name: "logout",
+			end: func(t *testing.T, r *Router, token string, _ int64) {
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/logout", nil)
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: token})
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("logout returned %d: %s", w.Code, w.Body.String())
+				}
+			},
+		},
+		{
+			name: "password change purges other sessions",
+			end: func(t *testing.T, r *Router, token string, userID int64) {
+				// A second session for the same operator does the changing, so
+				// the one under test is an "other" session.
+				other, err := r.db.CreateSession(userID, time.Hour)
+				if err != nil {
+					t.Fatal(err)
+				}
+				body := `{"old_password":"hunter2hunter2","new_password":"correct-horse-battery"}`
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/auth/change-password", strings.NewReader(body))
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: other.Token})
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
+				if w.Code != http.StatusOK {
+					t.Fatalf("change-password returned %d: %s", w.Code, w.Body.String())
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newTestServer(t)
+			r := ctx.srv.router
+
+			user, err := r.db.CreateUser("operator", "hunter2hunter2")
+			if err != nil {
+				t.Fatal(err)
+			}
+			sess, err := r.db.CreateSession(user.ID, time.Hour)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			probe := func() int {
+				req := httptest.NewRequest(http.MethodGet, "/api/v1/functions", nil)
+				req.AddCookie(&http.Cookie{Name: "session_token", Value: sess.Token})
+				w := httptest.NewRecorder()
+				r.ServeHTTP(w, req)
+				return w.Code
+			}
+
+			// Warm the memo, or the middleware just misses and 401s for a
+			// reason that has nothing to do with eviction.
+			if got := probe(); got == http.StatusUnauthorized {
+				t.Fatalf("the session did not authenticate before revocation (got %d)", got)
+			}
+			if _, cached := r.sessionCache.Load(sess.Token); !cached {
+				t.Fatal("the session never entered the memo, so an eviction cannot be observed here")
+			}
+
+			tc.end(t, r, sess.Token, user.ID)
+
+			if got := probe(); got != http.StatusUnauthorized {
+				t.Errorf("a revoked session cookie still authenticated: GET /api/v1/functions returned %d, want 401", got)
+			}
+			if _, cached := r.sessionCache.Load(sess.Token); cached {
+				t.Error("the revoked session is still in the memo")
+			}
+		})
+	}
+}

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -388,11 +388,12 @@ func (r *Router) setupRoutes() {
 
 	// API Key management routes.
 	//
-	// One closure, held by every surface that can revoke a key. keyCache has
-	// no TTL, so a revocation that skips this eviction is not slow -- it never
-	// happens, and the key keeps authenticating until the process restarts.
-	// MCP's delete tool shipped without it for exactly as long as it was a
-	// second copy of the idea rather than the same one.
+	// One closure, held by every surface that can revoke a key. The TTL on a
+	// cache entry bounds a missed eviction; it does not perform one, and a key
+	// that keeps working for another thirty seconds after you revoked it is
+	// still a key that kept working. MCP's delete tool shipped without this
+	// for exactly as long as it was a second copy of the idea rather than the
+	// same one.
 	invalidateKey := func(keyHash string) { r.keyCache.Delete(keyHash) }
 	keyHandler := &handlers.KeyHandler{
 		DB:            r.db,

--- a/backend/internal/server/router.go
+++ b/backend/internal/server/router.go
@@ -43,7 +43,12 @@ type Router struct {
 
 	ai *aipkg.Manager // in-product AI chat assistant (lazily-built LLM gateway)
 
-	keyCache sync.Map // shared API-key cache (keyHash -> *database.APIKey); evicted on key delete
+	keyCache sync.Map // shared API-key cache (keyHash -> keyCacheEntry); evicted on key delete
+	// sessionCache (token -> sessionCacheEntry) is owned here for the same
+	// reason keyCache is: logout, revoke-device and the password-change purge
+	// all have to evict, and a cache declared inside the middleware is
+	// unreachable from any of them.
+	sessionCache sync.Map
 
 	startTime time.Time
 }
@@ -342,6 +347,7 @@ func (r *Router) setupRoutes() {
 		DB:                r.db,
 		SecureCookies:     r.cfg.Security.SecureCookies,
 		SessionMaxAgeSecs: r.cfg.Security.SessionDays * 24 * 60 * 60,
+		InvalidateSession: func(token string) { r.sessionCache.Delete(token) },
 	}
 	r.mux.HandleFunc("GET /api/v1/auth/status", authHandler.Status)
 	r.mux.HandleFunc("POST /api/v1/auth/onboard", authHandler.Onboard)
@@ -381,11 +387,16 @@ func (r *Router) setupRoutes() {
 	r.mux.HandleFunc("GET /api/v1/syscalls", syscallHandler.List)
 
 	// API Key management routes.
+	//
+	// One closure, held by every surface that can revoke a key. keyCache has
+	// no TTL, so a revocation that skips this eviction is not slow -- it never
+	// happens, and the key keeps authenticating until the process restarts.
+	// MCP's delete tool shipped without it for exactly as long as it was a
+	// second copy of the idea rather than the same one.
+	invalidateKey := func(keyHash string) { r.keyCache.Delete(keyHash) }
 	keyHandler := &handlers.KeyHandler{
-		DB: r.db,
-		// Evict the deleted key from the shared auth cache so revocation is
-		// immediate (otherwise a cached key keeps authenticating).
-		InvalidateKey: func(keyHash string) { r.keyCache.Delete(keyHash) },
+		DB:            r.db,
+		InvalidateKey: invalidateKey,
 	}
 	r.mux.HandleFunc("POST /api/v1/keys", keyHandler.Create)
 	r.mux.HandleFunc("GET /api/v1/keys", keyHandler.List)
@@ -455,6 +466,7 @@ func (r *Router) setupRoutes() {
 		Version:        version.Version,
 		NsjailBin:      r.cfg.Sandbox.NsjailBin,
 		AllowedOrigins: r.cfg.Security.CORSOrigins,
+		InvalidateKey:  invalidateKey,
 	}
 	mcpHandler := orvampc.NewHandler(mcpDeps)
 	r.mux.Handle("/mcp", mcpHandler)
@@ -559,7 +571,7 @@ func (r *Router) buildMiddlewareChain() {
 	// Build chain from inside out: Handler -> Logger -> RequestID -> Auth -> BodySize -> CORS
 	chain := loggerMiddleware(r.db, r.eventHub, r.mux)
 	chain = requestIDMiddleware(chain)
-	chain = authMiddleware(r.db, &r.keyCache, r.sdkAuth, chain)
+	chain = authMiddleware(r.db, &r.keyCache, &r.sessionCache, r.sdkAuth, chain)
 	chain = bodySizeMiddleware(maxBody, chain)
 	chain = corsMiddleware(origins, chain)
 


### PR DESCRIPTION
Closes the last open item from the old remediation plan, and two more the audit for it turned up.

Revoking a credential has two halves: delete the row, and evict the in-memory memo the auth middleware answers from. Three surfaces did only the first.

## 1. API keys revoked via MCP / the AI assistant (high)

`delete_api_key` called `DeleteAPIKey` and stopped. The REST handler had always evicted.

`/mcp` and `/fn/` resolve credentials straight from the database, so the key **died on exactly the surface it was revoked from** and kept full REST access — minting keys, reading secrets, `GET /api/v1/backup` — until the process restarted. The AI sidebar is the likeliest place an operator revokes a key, and it reported success. The tool's own description promises *"Active sessions using that key fail their next request with 401."*

`keyCache` is a bare `sync.Map`. Expiry **is** re-checked on the cached path, so a key with `expires_at` was bounded by its own expiry — but REST defaults `expires_at` to nil and MCP accepts `expires_in_days=0`, and those never self-evicted.

The eviction was a second copy of the idea rather than the same one, so the closure is now built once in the router and shared. There is exactly one `mcp.Deps` construction site and the AI manager copies that struct, so `/mcp` and the sidebar are covered together.

## 2. Sessions (high — worse, same shape)

`sessionCache` was declared **inside** `authMiddleware`, so no handler could evict it even in principle. Logout, revoke-device, the password-change purge and `Refresh`'s old-token delete all removed the row and left the memo — and the session branch checks no permissions at all, so that is up to 30 seconds of full operator access on every route. For a password change it is precisely the window the purge exists to close.

`sessionCache` is Router-owned now, like `keyCache`, and every path that ends a session goes through one helper. `DeleteSessionByPrefix` and `DeleteUserSessionsExcept` return the tokens they revoked, because a prefix and a count cannot evict anything.

## 3. The backstop

`keyCache` had no TTL, so a missed eviction was permanent rather than slow — `sessionCache` next door had used 30s all along. Keys now match. Both call sites evict directly; this is what makes the *next* one added a 30-second bug instead of an unbounded one.

Also: the REST delete path silently skipped eviction when its pre-delete lookup failed and still answered 200. It logs now, as MCP does.

## Verification

Every test was run against the pre-fix code and shown to fail:

| Test | Pre-fix |
|---|---|
| `KeyRevokedThroughMCPStopsWorkingOnTheRESTAPI` | revoked key → `GET /api/v1/functions` **200** |
| ...with the tool fixed but the router un-wired | **200** — catches the way this bug was introduced |
| `EndingASessionStopsTheCookieImmediately/logout` | logged-out cookie → **200** |
| `.../password change purges other sessions` | purged cookie → **200** |
| `DeleteAPIKeyToolEvictsTheAuthCache` | `evicted = []` |
| `AStaleKeyCacheEntryExpiresOnItsOwn` | no TTL to expire |

The end-to-end tests warm the cache first and assert the entry is present — without that they would pass for the wrong reason, since an unwarmed lookup misses and 401s regardless.

`go vet` + `go test ./...` clean; `-race` clean on `server`, `mcp`, `handlers`, `database`.

## Not fixed here

The audit also found: the SDK worker credential (`sdkauth`) is an unexpiring HMAC over the function ID with **no revocation path at all** — redeploying a compromised function does not rotate it; and revoking an API key does not revoke channel tokens or OAuth grants it minted (no owning-key column exists). Both are design questions rather than missed evictions, so they are reported, not bundled.