### PR TITLE
docs(changelog): cut v2026.08.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,19 @@ section of every release between your current version and the one you are
 upgrading to.**
 
 Entries describe what changes *for an operator*. Implementation detail lives in
-the commit messages; `git log v2026.08.05..HEAD` is the full record.
+the commit messages; `git log v2026.08.21..HEAD` is the full record.
 
 ## Unreleased
+
+Nothing yet.
+
+## v2026.08.25
+
+Three things in this release need an operator's attention rather than just a
+read: `crons.upsert` is now handler-scoped (**Breaking**, below), an API key you
+revoked through the AI assistant may still be live until you restart, and if you
+copied `ORVA_SECURE_COOKIES=true` out of the old `docker-compose.yml` onto a
+plain-HTTP instance, remove it.
 
 ### Breaking
 
@@ -33,6 +43,22 @@ the commit messages; `git log v2026.08.05..HEAD` is the full record.
   `crons.upsert` call inside your handler and `await` it. Registration is
   idempotent by `(function, name)`, so calling it on every invocation is fine —
   and is what the documentation already shows.
+
+### Upgrade notes
+
+- **Restart Orva after upgrading if you have ever revoked an API key through
+  the AI assistant or an MCP client.** Those revocations deleted the key but
+  left it in the authentication cache, so it may still be working on the REST
+  API right now. A restart clears the cache; the fix below stops it recurring.
+  Keys revoked from the dashboard or `orva keys revoke` were never affected.
+
+- **If you copied `ORVA_SECURE_COOKIES=true` from the old `docker-compose.yml`
+  into your own compose file, and you reach Orva over plain HTTP, remove it.**
+  It is why signing in from a LAN address bounces you back to the login screen.
+  The shipped compose file no longer sets it.
+
+- Nothing else to do. No migration, no configuration change, no re-issued
+  credentials.
 
 ### Added
 
@@ -221,6 +247,30 @@ the commit messages; `git log v2026.08.05..HEAD` is the full record.
   deleting a rule already compiles and publishes a new policy generation; the
   button re-resolves hostname rules to current IPs. Calling it "Apply" implied
   blocks sat inert until it was pressed.
+
+### Verified
+
+Beyond CI's gate (`test/e2e/run.py` with `ORVA_REQUIRE_SANDBOX=1` on amd64 and
+arm64, the server and CLI installers, native systemd, docker smoke, CodeQL):
+
+- **Every regression test in this release was run against the unfixed code and
+  shown to fail first.** That is not a formality here — five tests written for
+  these fixes passed against the code they were meant to pin, and were rebuilt
+  until they failed: a traversal at the wrong depth, an escape planted one
+  directory off, a cache TTL that still passed with the timeout set to eleven
+  years, a route table every handler already rejected, and two session
+  revocation paths that could be neutered with the suite staying green. Two
+  tests that legitimately pass both ways are labelled in-file as controls.
+- **`go test -race`** on `server`, `handlers`, `database` and `mcp` after each
+  change, locally.
+- **The migration surface is untouched.** Nothing in this release adds,
+  alters or reads a migration; the OAuth work reuses columns that already
+  exist on every installed instance.
+
+Not run for this release: `test/atscale.sh` and the migration rehearsal. Neither
+is implicated — no pool, scheduler-capacity or migration behaviour changed — but
+CONTRACT §6 lists them as beyond CI, so their absence is stated rather than
+implied.
 
 ## v2026.08.21
 


### PR DESCRIPTION
Release prep only — no code changes. `CHANGELOG.md` alone.

Moves `Unreleased` under a dated heading, which CONTRACT §7 requires before tagging.

## What's in the release

Four merged PRs: #51 (TypeScript entrypoint split, rollback promotion, UI audit), #52 (build path containment, cookie scheme), #53 (credential revocation eviction), #54 (the credential-architecture panel's findings).

## Two things upgrading does not fix

Both now have their own **Upgrade notes** entries, because in both cases the leftover state is outside the binary:

- **An API key revoked through the AI assistant or an MCP client may still be live.** Those revocations deleted the row but left the key in the running process's auth cache. Upgrading replaces the binary and clears the cache with it — but an operator who does not restart, or who reads this after the fact, should know why. Keys revoked from the dashboard or `orva keys revoke` were never affected.
- **`ORVA_SECURE_COOKIES=true` copied out of the old `docker-compose.yml`** stays in the operator's own file. We stopped shipping it; their compose still has it, and it is why signing in from a LAN address bounces back to the login screen.

The lead paragraph names those two plus the `crons.upsert` breaking change, so a skim answers "does this ask anything of me?" in three lines.

## Verified section

States what was checked beyond CI **and what was not**. Worth calling out for this release: **five tests written for these fixes passed against the code they were meant to pin** and had to be rebuilt until they failed — a traversal at the wrong depth, an escape planted one directory off, a TTL test that still passed with the timeout set to eleven years, a route table every handler already rejected, and two session-revocation paths that could be neutered with the suite green. "The tests pass" would have been a misleading summary of the evidence, so the discipline is recorded rather than the outcome.

`test/atscale.sh` and the migration rehearsal were **not** run. Neither is implicated — no pool, scheduler-capacity or migration behaviour changed, and the OAuth work reuses columns that already exist on every instance — but CONTRACT §6 lists them as beyond CI, so their absence is stated rather than left to inference.

## After this merges

Nothing is tagged by this PR. The release gate needs `CI` green on the exact tagged commit, so the tag goes on the merge commit of this PR once its checks pass.