### PR TITLE
fix(sdkauth): bind the worker credential to its worker, so redeploy remediates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,22 @@ before it.
 
 ## Unreleased
 
-Nothing yet.
+### Fixed
+
+- **Redeploying a function now invalidates a leaked SDK credential.** The
+  `ORVA_INTERNAL_TOKEN` your function's code holds was derived from the
+  function's ID alone, so it was identical across deploys: if a compromised
+  dependency copied it, removing that dependency and redeploying re-issued the
+  same token, and only restarting Orva cleared it. The documented remediation
+  therefore looked like it worked and did not.
+
+  Each credential now also names the worker process it was issued to, and dies
+  when that process does. Redeploying retires a function's warm workers, so it
+  is a real remediation. Credentials still expire on restart, and on ordinary
+  worker recycling (idle timeout, use limit).
+
+  Nothing to do on upgrade: credentials are minted at spawn and every worker is
+  replaced when you restart into the new version.
 
 ## v2026.08.25
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -39,7 +39,7 @@ go vet ./...
 | `metrics` | Prometheus-text counters + histograms (no external deps, atomic ops) |
 | `safepath` | Containment for user-supplied relative paths. `Validate` on the write side so a bad `entrypoint` never reaches storage; `Join` on the read side, which must hold independently because rows written before validation still carry whatever they carry. Traversal is rejected, not collapsed. |
 | `secrets` | AES-256-GCM encrypted secrets per function. The key lives at `<dataDir>/.master.key`, outside the database — back it up with `orva.db` or restored secrets are undecryptable ciphertext |
-| `sdkauth` | Mints and verifies the worker credential (`ORVA_INTERNAL_TOKEN`). HMAC over the function id under a **process-random** key, so every credential dies on restart and a redeploy does **not** rotate one. `active` tracks live executions, which is what the SDK surfaces that require one check against |
+| `sdkauth` | Mints and verifies the worker credential (`ORVA_INTERNAL_TOKEN`). HMAC over the function id **and a per-spawn nonce**, under a process-random key — so a credential dies both when orvad restarts and when the worker it was issued to is reaped. `Mint` returns a release; the pool wires it to `sandbox.ExecConfig.OnExit` and must also call it on every spawn error path. `live` holds the nonces, `active` the executions the gated SDK surfaces check against |
 | `scheduler` | Cron runner (`robfig/cron/v3`) |
 | `mcp` | MCP server (go-sdk); 73 operator-management tools OR channel-mode (one tool per bundled function, invoke-only). Auth accepts API keys, OAuth 2.1 access tokens, OR channel tokens. **Transport is stateless** (`StreamableHTTPOptions{Stateless: true}`) — the SDK serves protocol `2026-07-28` only in that mode, and older clients still negotiate down. No `initialize` handshake required, no `Mcp-Session-Id`, `GET`/`DELETE /mcp` → 405. Operator servers are cached by the four-bit permission surface (at most 16 variants); channel servers remain request-scoped. Actor identity and public origin live in request context, so cached servers cannot cross-label activity or leak one host into another's `invoke_url`. A process-wide `ServerOptions.SchemaCache` keeps `AddTool` reflection off first-build paths. `cacheScopeMiddleware` rewrites the SDK's hardcoded `cacheScope: "public"` to `"private"` — the catalog is permission- and channel-scoped, so a shared HTTP cache entry would leak one principal's tool surface to another. |
 | `oauth` | OAuth 2.1 authorization server (RFC 7591 DCR + RFC 8414 metadata + PKCE S256 + RFC 8707 resource indicators + RFC 7009 revocation). Lets claude.ai/ChatGPT add `/mcp` as a custom connector via the browser. Connected apps + sessions managed at `/api/v1/oauth/connected-apps`, `DELETE /api/v1/oauth/clients/{client_id}` (retires an application: revokes its grants, drops pending codes, blocks re-authorization without fresh consent) and `/api/v1/auth/sessions` and surfaced in the dashboard's Settings page. DCR default scope is `read invoke write admin`; a client's **registered** scope is a ceiling, applied via `IntersectScope` on both authorize paths, so a client registered `read` cannot be issued `admin`. |
@@ -116,6 +116,13 @@ SQLite WAL mode. All migrations in `internal/database/migrations.go` — additiv
   spawn with no execution bound, and the docs tell operators to cache config
   there, so an execution gate on KV would break a documented pattern silently
   at cold start.
+- **The SDK credential's release is wired to the reaper, not to Kill or to
+  retire.** `Kill` and `retirePool` express an intention to stop a worker; a
+  busy one keeps serving until it drains, so releasing there would 401 a live
+  request. The reaper goroutine in `sandbox/worker.go` is the only place the
+  process is known to be gone, and it covers every exit path. A missed release
+  leaks a map entry and degrades to the old behaviour — a credential valid
+  until restart — which is why the pool releases on its error paths too.
 - **Revocation evicts.** Every path that deletes an API key or ends a session
   must evict the auth middleware's cache; the entries carry a 30s TTL as a
   backstop, not as the mechanism. `router.go` builds one `invalidateKey`

--- a/backend/internal/pool/pool.go
+++ b/backend/internal/pool/pool.go
@@ -62,9 +62,15 @@ type SandboxTemplate struct {
 	// RefreshForDeploy so the next spawn picks up the new values.
 	SecretsLookup func(fnID string) map[string]string
 
-	// SDKToken mints a process-scoped credential bound to the worker's
+	// SDKToken mints a credential bound to one worker process, and returns
+	// the release that invalidates it when that worker dies. The release MUST
+	// run on every path after a successful mint -- including the spawn error
+	// paths below, where the worker the credential was minted for never came
+	// into existence.
+	//
+	// Previously bound to the worker's
 	// function ID. User code can read it, but cannot alter the signed caller.
-	SDKToken func(functionID string) string
+	SDKToken func(functionID string) (token string, release func())
 
 	// APIBaseURL is the base URL the adapter uses when making outbound
 	// calls to Orva's own internal endpoints (KV / F2F / jobs).
@@ -805,9 +811,12 @@ func (m *Manager) getOrCreatePool(fnID string) (*functionPool, error) {
 			// KV / F2F / jobs endpoints. Empty when running outside the
 			// server (tests) so user code can probe presence to decide
 			// whether to fall back.
+			releaseSDKToken := func() {}
 			if m.tmpl.SDKToken != nil {
-				env["ORVA_INTERNAL_TOKEN"] = m.tmpl.SDKToken(fn.ID)
+				token, release := m.tmpl.SDKToken(fn.ID)
+				env["ORVA_INTERNAL_TOKEN"] = token
 				env["ORVA_API_BASE"] = m.tmpl.APIBaseURL
+				releaseSDKToken = release
 			}
 			// Resolve the egress policy for this spawn. Read off m (not the
 			// local tmpl copy) so a late SetEgressPolicy is visible to pools
@@ -821,7 +830,8 @@ func (m *Manager) getOrCreatePool(fnID string) (*functionPool, error) {
 				if getPolicy := m.tmpl.EgressPolicy; getPolicy != nil {
 					p, g, perr := getPolicy()
 					if perr != nil {
-						return nil, perr // fail closed: no policy, no worker
+						releaseSDKToken() // no worker will ever hold this
+						return nil, perr  // fail closed: no policy, no worker
 					}
 					policyPath, policyGen = p, g
 				}
@@ -855,11 +865,21 @@ func (m *Manager) getOrCreatePool(fnID string) (*functionPool, error) {
 				NsjailBin:        tmpl.NsjailBin,
 				RootfsDir:        tmpl.RootfsDir,
 				Timeout:          time.Duration(fn.TimeoutMS) * time.Millisecond,
+				// Released once this worker's process is reaped, whichever way
+				// it dies. That is what expires the credential on redeploy:
+				// RefreshForDeploy retires the function's workers, and each
+				// one's credential dies with its process.
+				OnExit: releaseSDKToken,
 			})
-			if err == nil && m.tmpl.Metrics != nil {
+			if err != nil {
+				// No process, so nothing will ever call OnExit for it.
+				releaseSDKToken()
+				return nil, err
+			}
+			if m.tmpl.Metrics != nil {
 				m.tmpl.Metrics.RecordSpawnDuration(time.Since(start))
 			}
-			return w, err
+			return w, nil
 		},
 	}
 	p.dynamicMax.Store(int64(initialMax))

--- a/backend/internal/pool/sdk_credential_release_test.go
+++ b/backend/internal/pool/sdk_credential_release_test.go
@@ -1,0 +1,123 @@
+package pool
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// The SDK credential is bound to one worker process: Mint hands back a release
+// that expires it, and the pool must call that release on every path where the
+// worker it was minted for does not end up running.
+//
+// This is the half the sdkauth tests cannot cover. sdkauth proves a released
+// credential stops verifying; this proves the pool actually releases. Get the
+// wiring wrong and the credential silently reverts to its old lifetime -- valid
+// until the process restarts -- with nothing failing anywhere.
+//
+// The reaper path (a worker that spawned and later died) is covered by the
+// gated sandbox E2E, since it needs a real nsjail process to reap.
+func TestSpawnFailureReleasesTheSDKCredential(t *testing.T) {
+	m, reg := egressTestManager(t)
+	tmpl := fakeSandboxTemplate(t)
+
+	var mu sync.Mutex
+	minted, released := 0, 0
+	tmpl.SDKToken = func(string) (string, func()) {
+		mu.Lock()
+		minted++
+		mu.Unlock()
+		return "orva-test-token", func() {
+			mu.Lock()
+			released++
+			mu.Unlock()
+		}
+	}
+
+	t.Run("egress policy unavailable", func(t *testing.T) {
+		// Fails closed BEFORE Spawn, and it is the path most likely to be
+		// missed: it returns early from the middle of the closure.
+		tmpl.EgressPolicy = func() (string, string, error) { return "", "", errTestNoPolicy }
+		m.tmpl = tmpl
+		fn := registerFn(t, reg, "cred-egress", "egress")
+
+		p, err := m.getOrCreatePool(fn.ID)
+		if err != nil {
+			t.Fatalf("getOrCreatePool: %v", err)
+		}
+		if _, err := p.spawnFn(context.Background()); err == nil {
+			t.Fatal("spawn succeeded without an egress policy")
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if minted == 0 {
+			t.Fatal("no credential was minted, so this asserts nothing")
+		}
+		if released != minted {
+			t.Errorf("minted %d credentials, released %d: a credential outlived a worker that never started",
+				minted, released)
+		}
+	})
+
+	t.Run("worker death releases it", func(t *testing.T) {
+		mu.Lock()
+		minted, released = 0, 0
+		mu.Unlock()
+		// network_mode=none needs no egress policy, so this reaches Spawn.
+		tmpl.EgressPolicy = nil
+		m.tmpl = tmpl
+		fn := registerFn(t, reg, "cred-none", "none")
+
+		p, err := m.getOrCreatePool(fn.ID)
+		if err != nil {
+			t.Fatalf("getOrCreatePool: %v", err)
+		}
+		w, err := p.spawnFn(context.Background())
+		if err != nil {
+			// Spawn failed instead: the release must still have run, and the
+			// reaper path is then covered by the gated sandbox E2E.
+			mu.Lock()
+			defer mu.Unlock()
+			if released != minted {
+				t.Errorf("a failed spawn left %d of %d credentials valid", minted-released, minted)
+			}
+			return
+		}
+
+		mu.Lock()
+		mintedNow := minted
+		releasedNow := released
+		mu.Unlock()
+		if mintedNow == 0 {
+			t.Fatal("no credential was minted, so this asserts nothing")
+		}
+		if releasedNow != 0 {
+			t.Fatal("the credential was released while its worker was still alive: live SDK calls would 401")
+		}
+
+		// Kill it and let the reaper run. Kill returns as soon as the signal
+		// is delivered, so poll for the release rather than assuming it is
+		// synchronous.
+		if err := w.Kill(); err != nil {
+			t.Fatalf("kill: %v", err)
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for {
+			mu.Lock()
+			done := released == mintedNow
+			mu.Unlock()
+			if done {
+				return
+			}
+			if time.Now().After(deadline) {
+				mu.Lock()
+				got := released
+				mu.Unlock()
+				t.Fatalf("released %d of %d credentials 5s after the worker died: the credential outlives its worker, which is the bug this change exists to fix",
+					got, mintedNow)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	})
+}

--- a/backend/internal/sandbox/sandbox.go
+++ b/backend/internal/sandbox/sandbox.go
@@ -49,6 +49,15 @@ type ExecConfig struct {
 	// both function config env_vars and decrypted secrets at invoke time.
 	Env map[string]string
 
+	// OnExit runs once, after this worker's process has been reaped. It is
+	// invoked from the single goroutine that owns cmd.Wait() (see worker.go),
+	// so it observes every exit path -- clean quit, SIGKILL, child crash,
+	// context cancel -- and never fires while the process is still alive.
+	//
+	// Used to release the worker's SDK credential. It must be cheap and must
+	// not block: it runs inline in the reaper, ahead of the cgroup reclaim.
+	OnExit func()
+
 	// Seccomp policy (Kafel string). Empty means no seccomp filter.
 	SeccompPolicy string
 

--- a/backend/internal/sandbox/worker.go
+++ b/backend/internal/sandbox/worker.go
@@ -172,6 +172,16 @@ func Spawn(ctx context.Context, cfg ExecConfig) (*Worker, error) {
 		w.dead.Store(true)
 		close(w.waitDone)
 
+		// The worker is genuinely gone now, so anything scoped to its
+		// lifetime can be torn down. This is the only place that is true for
+		// every exit path, which is why the SDK-credential release is wired
+		// here rather than to Kill or to the pool's retire path: those two
+		// express an intention to stop the worker, and a busy one keeps
+		// serving until it drains. Releasing there would 401 a live request.
+		if cfg.OnExit != nil {
+			cfg.OnExit()
+		}
+
 		// Reclaim the cgroup HERE, not at Kill time. nsjail is SIGKILLed, so
 		// it never runs its own cleanup and the NSJAIL.<pid> directory it
 		// created is left behind; but rmdir on a cgroup fails with EBUSY

--- a/backend/internal/sdkauth/auth.go
+++ b/backend/internal/sdkauth/auth.go
@@ -1,10 +1,21 @@
-// Package sdkauth issues and verifies process-scoped credentials for sandbox
-// workers. A credential binds the worker to one immutable function ID; the
-// process-random signing key makes every credential expire on server restart.
+// Package sdkauth issues and verifies credentials for sandbox workers.
+//
+// A credential names one immutable function ID and one specific worker
+// process. The process-random signing key expires every credential on server
+// restart; the per-spawn nonce expires each one when its own worker dies.
+//
+// The nonce is what makes redeploy a real remediation. Without it a credential
+// was a pure function of (signing key, function ID), so a copy exfiltrated by a
+// compromised dependency kept working against the replacement code -- the
+// operator removed the dependency, redeployed, and the stolen token was
+// re-minted byte-identical. Only a full restart cleared it. Now a redeploy
+// retires the function's warm workers, each worker's nonce dies with its
+// process, and the copy stops working.
 package sdkauth
 
 import (
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -13,13 +24,17 @@ import (
 	"time"
 )
 
-const tokenVersion = "v1"
+// v2 added the nonce. There is no v1 compatibility to keep: the signing key is
+// process-random, so no credential survives the restart that deploys a new
+// binary anyway.
+const tokenVersion = "v2"
 
 var ErrInvalidToken = errors.New("invalid SDK credential")
 
 type Authenticator struct {
 	key    []byte
 	active sync.Map // execution ID -> activeExecution while a worker is dispatching
+	live   sync.Map // nonce -> struct{} while the worker that received it is alive
 }
 
 type activeExecution struct {
@@ -78,15 +93,33 @@ func New(key []byte) *Authenticator {
 	return &Authenticator{key: append([]byte(nil), key...)}
 }
 
-func (a *Authenticator) Mint(functionID string) string {
+// Mint issues a credential for one worker process and returns a release
+// function that invalidates it. The caller must call release when that worker
+// dies, and on every path where the spawn it was minted for does not happen.
+//
+// Failing to release leaks one map entry and degrades to the pre-nonce
+// behaviour -- the credential stays valid until the process restarts. Releasing
+// too early would 401 a live worker, which is why the release is wired to the
+// reaper that observes the process actually exiting rather than to any code
+// path that merely intends to stop it.
+func (a *Authenticator) Mint(functionID string) (string, func()) {
+	noop := func() {}
 	if a == nil || len(a.key) == 0 || functionID == "" {
-		return ""
+		return "", noop
 	}
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", noop
+	}
+	encodedNonce := base64.RawURLEncoding.EncodeToString(nonce)
 	encodedID := base64.RawURLEncoding.EncodeToString([]byte(functionID))
-	payload := tokenVersion + "." + encodedID
+	payload := tokenVersion + "." + encodedID + "." + encodedNonce
 	mac := hmac.New(sha256.New, a.key)
 	_, _ = mac.Write([]byte(payload))
-	return payload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	a.live.Store(encodedNonce, struct{}{})
+	release := func() { a.live.Delete(encodedNonce) }
+	return payload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil)), release
 }
 
 func (a *Authenticator) Verify(token string) (string, error) {
@@ -94,17 +127,23 @@ func (a *Authenticator) Verify(token string) (string, error) {
 		return "", ErrInvalidToken
 	}
 	parts := strings.Split(token, ".")
-	if len(parts) != 3 || parts[0] != tokenVersion {
+	if len(parts) != 4 || parts[0] != tokenVersion {
 		return "", ErrInvalidToken
 	}
-	payload := parts[0] + "." + parts[1]
-	gotMAC, err := base64.RawURLEncoding.DecodeString(parts[2])
+	payload := parts[0] + "." + parts[1] + "." + parts[2]
+	gotMAC, err := base64.RawURLEncoding.DecodeString(parts[3])
 	if err != nil {
 		return "", ErrInvalidToken
 	}
 	mac := hmac.New(sha256.New, a.key)
 	_, _ = mac.Write([]byte(payload))
 	if !hmac.Equal(gotMAC, mac.Sum(nil)) {
+		return "", ErrInvalidToken
+	}
+	// A valid signature is not enough: the worker this was minted for must
+	// still be alive. This is the check that makes an exfiltrated copy stop
+	// working when the function is redeployed.
+	if _, alive := a.live.Load(parts[2]); !alive {
 		return "", ErrInvalidToken
 	}
 	rawID, err := base64.RawURLEncoding.DecodeString(parts[1])

--- a/backend/internal/sdkauth/auth_test.go
+++ b/backend/internal/sdkauth/auth_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestScopedCredential(t *testing.T) {
 	a := New([]byte("01234567890123456789012345678901"))
-	token := a.Mint("function-a")
+	token, release := a.Mint("function-a")
 	got, err := a.Verify(token)
 	if err != nil || got != "function-a" {
 		t.Fatalf("verify = %q, %v", got, err)
@@ -24,6 +24,74 @@ func TestScopedCredential(t *testing.T) {
 			t.Fatal("credential signed by a prior process was accepted")
 		}
 	})
+	t.Run("dead once its worker is released", func(t *testing.T) {
+		release()
+		if _, err := a.Verify(token); err == nil {
+			t.Fatal("credential outlived the worker it was minted for")
+		}
+	})
+}
+
+// The credential names one worker process, not just a function. That is what
+// makes redeploy a real remediation: it used to be a pure function of
+// (signing key, function id), so a copy taken by a compromised dependency was
+// re-minted byte-identical by the deploy meant to remove it, and only a full
+// server restart cleared it.
+func TestEachSpawnGetsADistinctCredential(t *testing.T) {
+	a := New([]byte("01234567890123456789012345678901"))
+
+	first, releaseFirst := a.Mint("fn-a")
+	second, releaseSecond := a.Mint("fn-a")
+	defer releaseSecond()
+
+	if first == second {
+		t.Fatal("two spawns of the same function got identical credentials: a stolen one survives redeploy")
+	}
+	for _, tok := range []string{first, second} {
+		if got, err := a.Verify(tok); err != nil || got != "fn-a" {
+			t.Fatalf("Verify = %q, %v; both live credentials must work", got, err)
+		}
+	}
+
+	// Retiring one worker must not touch the other's -- deploys drain busy
+	// workers, so the two overlap.
+	releaseFirst()
+	if _, err := a.Verify(first); err == nil {
+		t.Error("the retired worker's credential still verified")
+	}
+	if got, err := a.Verify(second); err != nil || got != "fn-a" {
+		t.Errorf("the surviving worker's credential was invalidated too: %q, %v", got, err)
+	}
+}
+
+// Releasing twice, or releasing a credential that was never issued, must be
+// harmless: the pool calls release on spawn error paths as well as from the
+// reaper, and both can run for the same mint.
+func TestReleaseIsIdempotent(t *testing.T) {
+	a := New([]byte("01234567890123456789012345678901"))
+	token, release := a.Mint("fn-a")
+	release()
+	release()
+	if _, err := a.Verify(token); err == nil {
+		t.Fatal("credential verified after release")
+	}
+}
+
+// A nil authenticator and an empty function id both yield an unusable
+// credential and a release that does nothing, so callers need no nil checks.
+func TestMintDegradesSafely(t *testing.T) {
+	var nilAuth *Authenticator
+	if tok, rel := nilAuth.Mint("fn-a"); tok != "" || rel == nil {
+		t.Error("nil authenticator did not degrade safely")
+	} else {
+		rel()
+	}
+	a := New([]byte("01234567890123456789012345678901"))
+	if tok, rel := a.Mint(""); tok != "" || rel == nil {
+		t.Error("empty function id did not degrade safely")
+	} else {
+		rel()
+	}
 }
 
 func TestExecutionOwnershipIsScopedAndRemoved(t *testing.T) {

--- a/backend/internal/server/handlers/fixtures.go
+++ b/backend/internal/server/handlers/fixtures.go
@@ -16,9 +16,9 @@ import (
 	"strings"
 
 	"github.com/Harsh-2002/Orva/backend/internal/database"
-	"github.com/Harsh-2002/Orva/internal/ids"
 	"github.com/Harsh-2002/Orva/backend/internal/registry"
 	"github.com/Harsh-2002/Orva/backend/internal/server/handlers/respond"
+	"github.com/Harsh-2002/Orva/internal/ids"
 )
 
 // fixtureBodyCap matches the KV operator surface: 64 KB body + a small

--- a/backend/internal/server/handlers/invoke.go
+++ b/backend/internal/server/handlers/invoke.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Harsh-2002/Orva/backend/internal/database"
-	"github.com/Harsh-2002/Orva/internal/ids"
 	"github.com/Harsh-2002/Orva/backend/internal/metrics"
 	"github.com/Harsh-2002/Orva/backend/internal/proxy"
 	"github.com/Harsh-2002/Orva/backend/internal/registry"
@@ -17,6 +16,7 @@ import (
 	"github.com/Harsh-2002/Orva/backend/internal/secrets"
 	"github.com/Harsh-2002/Orva/backend/internal/server/handlers/respond"
 	"github.com/Harsh-2002/Orva/backend/internal/trace"
+	"github.com/Harsh-2002/Orva/internal/ids"
 )
 
 // InvokeHandler handles function invocation requests.

--- a/backend/internal/server/handlers/sdk_auth_test.go
+++ b/backend/internal/server/handlers/sdk_auth_test.go
@@ -34,7 +34,7 @@ func TestKVScopedCredentialRejectsCrossNamespaceAndCallerSpoof(t *testing.T) {
 	cross := httptest.NewRequest(http.MethodPut, "/api/v1/_kv/fn-sdk-b/key", bytes.NewBufferString(`{"value":1}`))
 	cross.SetPathValue("fn_id", "fn-sdk-b")
 	cross.SetPathValue("key", "key")
-	cross.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-sdk-a"))
+	cross.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-sdk-a"))
 	cross.Header.Set("X-Orva-Caller-Function", "fn-sdk-b")
 	crossResult := httptest.NewRecorder()
 	h.Put(crossResult, cross)
@@ -45,7 +45,7 @@ func TestKVScopedCredentialRejectsCrossNamespaceAndCallerSpoof(t *testing.T) {
 	spoof := httptest.NewRequest(http.MethodPut, "/api/v1/_kv/fn-sdk-a/key", bytes.NewBufferString(`{"value":1}`))
 	spoof.SetPathValue("fn_id", "fn-sdk-a")
 	spoof.SetPathValue("key", "key")
-	spoof.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-sdk-a"))
+	spoof.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-sdk-a"))
 	spoof.Header.Set("X-Orva-Caller-Function", "fn-sdk-b")
 	spoofResult := httptest.NewRecorder()
 	h.Put(spoofResult, spoof)
@@ -70,7 +70,7 @@ func TestJobAttributionUsesSignedCaller(t *testing.T) {
 	h := &JobsHandler{DB: db, SDKAuth: auth}
 	body := bytes.NewBufferString(`{"function_name":"job-target","payload":{}}`)
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/jobs", body)
-	req.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-job-caller"))
+	req.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-job-caller"))
 	req.Header.Set("X-Orva-Caller-Function", "fn-spoof")
 	req.Header.Set("X-Orva-Execution-Id", "exec-job")
 	req.Header.Set("X-Orva-Trace-Id", "trace-spoof")
@@ -98,7 +98,7 @@ func TestUserSpanMustBelongToSignedCaller(t *testing.T) {
 	defer release()
 	h := &SpansHandler{DB: newTestDB(t), SDKAuth: auth}
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_internal/spans", bytes.NewBufferString(`{"name":"work","duration_ms":1}`))
-	req.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-other"))
+	req.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-other"))
 	req.Header.Set("X-Orva-Trace-Id", "trace")
 	req.Header.Set("X-Orva-Span-Id", "span")
 	req.Header.Set("X-Orva-Execution-Id", "exec-owned")
@@ -118,7 +118,7 @@ func TestCronUpsertUsesSignedCallerScope(t *testing.T) {
 	release := auth.BindExecution("exec-1", "fn-cron-owner", "trace-1", "span-1", time.Now())
 	defer release()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_internal/crons", bytes.NewBufferString(`{"name":"nightly","schedule":"0 3 * * *"}`))
-	req.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-cron-owner"))
+	req.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-cron-owner"))
 	req.Header.Set("X-Orva-Execution-Id", "exec-1")
 	req.Header.Set("X-Orva-Function-Id", "fn-cron-other")
 	w := httptest.NewRecorder()
@@ -168,7 +168,7 @@ func TestCronUpsertRequiresALiveExecution(t *testing.T) {
 			}
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/_internal/crons",
 				bytes.NewBufferString(`{"name":"planted","schedule":"* * * * *"}`))
-			req.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-cron-owner"))
+			req.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-cron-owner"))
 			if tc.executionID != "" {
 				req.Header.Set("X-Orva-Execution-Id", tc.executionID)
 			}
@@ -204,7 +204,7 @@ func TestSDKScheduleCountIsCapped(t *testing.T) {
 	upsert := func(name string) int {
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/_internal/crons",
 			bytes.NewBufferString(`{"name":"`+name+`","schedule":"* * * * *"}`))
-		req.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-cron-many"))
+		req.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-cron-many"))
 		req.Header.Set("X-Orva-Execution-Id", "exec-1")
 		w := httptest.NewRecorder()
 		h.UpsertInternal(w, req)
@@ -261,7 +261,7 @@ func TestTheScheduleCapIgnoresOperatorCreatedRows(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/_internal/crons",
 		bytes.NewBufferString(`{"name":"first-declared","schedule":"0 3 * * *"}`))
-	req.Header.Set("X-Orva-Internal-Token", auth.Mint("fn-cron-mixed"))
+	req.Header.Set("X-Orva-Internal-Token", mintLive(auth, "fn-cron-mixed"))
 	req.Header.Set("X-Orva-Execution-Id", "exec-1")
 	w := httptest.NewRecorder()
 	h.UpsertInternal(w, req)
@@ -270,4 +270,13 @@ func TestTheScheduleCapIgnoresOperatorCreatedRows(t *testing.T) {
 		t.Errorf("status=%d, want 200: this function has declared no schedules of its own; body=%s",
 			w.Code, w.Body.String())
 	}
+}
+
+// mintLive returns a credential whose worker is treated as alive for the rest
+// of the test. Mint now hands back a release that expires the credential when
+// the worker process dies; a test that never spawns one has nothing to release,
+// and dropping the release keeps the credential valid for the test's duration.
+func mintLive(a *sdkauth.Authenticator, functionID string) string {
+	token, _ := a.Mint(functionID)
+	return token
 }

--- a/backend/internal/server/internal_prefix_auth_test.go
+++ b/backend/internal/server/internal_prefix_auth_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/Harsh-2002/Orva/backend/internal/sdkauth"
 )
 
 // Everything under /api/v1/_kv/ and /api/v1/_internal/ authenticates with the
@@ -68,7 +70,7 @@ func TestEveryInternalPrefixRouteRejectsABadCredential(t *testing.T) {
 // would pass against a gate that rejected everything.
 func TestAValidSDKCredentialPassesTheInternalPrefixGate(t *testing.T) {
 	tc := newTestServer(t)
-	token := tc.srv.router.sdkAuth.Mint("fn_x")
+	token := mintLive(tc.srv.router.sdkAuth, "fn_x")
 	if token == "" {
 		t.Fatal("could not mint an SDK credential")
 	}
@@ -124,9 +126,15 @@ func TestTheGateRejectsBeforeTheHandlerRuns(t *testing.T) {
 	spy := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { reached = true })
 	gate := authMiddleware(r.db, &r.keyCache, &r.sessionCache, r.sdkAuth, spy)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/_kv/fn_x/k", nil)
-	req.Header.Set("X-Orva-Internal-Token", r.sdkAuth.Mint("fn_x"))
+	req.Header.Set("X-Orva-Internal-Token", mintLive(r.sdkAuth, "fn_x"))
 	gate.ServeHTTP(httptest.NewRecorder(), req)
 	if !reached {
 		t.Error("a valid SDK credential was rejected at the gate")
 	}
+}
+
+// mintLive: see the note on the identical helper in the handlers package.
+func mintLive(a *sdkauth.Authenticator, functionID string) string {
+	token, _ := a.Mint(functionID)
+	return token
 }

--- a/backend/internal/server/middleware_auth_test.go
+++ b/backend/internal/server/middleware_auth_test.go
@@ -15,7 +15,7 @@ import (
 // SDK credentials must never grant access to the broader operator API.
 func TestScopedSDKCredentialCannotBypassOperatorAuth(t *testing.T) {
 	tc := newTestServer(t)
-	real := tc.srv.router.sdkAuth.Mint("function-a")
+	real := mintLive(tc.srv.router.sdkAuth, "function-a")
 	if real == "" {
 		t.Fatal("scoped SDK credential is empty")
 	}

--- a/backend/internal/server/oauth_e2e_test.go
+++ b/backend/internal/server/oauth_e2e_test.go
@@ -377,9 +377,9 @@ func TestConsentScreenIsNativeOrva(t *testing.T) {
 		// Native Orva chrome: same brand mark, font, and colour
 		// tokens as the dashboard's Login.vue.
 		"Inter:wght",
-		`#0B0D10`,    // dashboard --color-background hex, baked into the inline CSS
-		`#553F83`,    // dashboard --color-primary (the Orva purple)
-		`f(x)`, // logo glyph
+		`#0B0D10`, // dashboard --color-background hex, baked into the inline CSS
+		`#553F83`, // dashboard --color-primary (the Orva purple)
+		`f(x)`,    // logo glyph
 		">Orva<",
 		// Application identity row uses the brand-aware icon class
 		// chosen by iconForConsent — emerald for ChatGPT.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -40,12 +40,15 @@ Orva is **not** designed to defend against:
 
 ## Sandbox SDK identity
 
-Each worker receives a process-signed SDK credential containing a token
-version and its immutable function ID. Orvad verifies the signature on KV,
+Each worker receives a signed SDK credential naming its immutable function ID
+and the specific worker process it was issued to. Orvad verifies the signature on KV,
 function invoke/streaming, job enqueue, cron upsert, and user-span requests;
 it never trusts `X-Orva-Caller-Function` for authorization or attribution.
-The signing key is random per process, so credentials copied from an old worker
-become invalid after restart.
+Two things expire it. The signing key is random per process, so every
+credential dies when orvad restarts. And the per-spawn identifier is dropped
+when that worker's process is reaped, so a credential copied out of one worker
+stops working as soon as that worker does — including when a redeploy retires
+it.
 
 KV access is limited to the credential's function namespace, cron upsert can
 only change that function's schedules, and user spans can only attach to an
@@ -65,12 +68,18 @@ anywhere that can reach the API. It cannot reach another function's KV, cannot
 authenticate to operator APIs, and cannot create or change a cron schedule —
 that requires a live execution of the function.
 
-**To remediate, remove the dependency, redeploy, and then restart orvad.** The
-restart is the part that invalidates the credential: the signing key is random
-per process, so every credential for every function dies with it. Redeploying
-alone does **not** rotate the credential — it is derived from the function's ID,
-which does not change — so a copy taken beforehand keeps working against the
-new code until the server restarts.
+**To remediate, remove the dependency and redeploy.** Redeploying retires all of
+that function's warm workers, and each worker's credential dies with its
+process, so a copy taken beforehand stops working. Credentials also expire when
+a worker is recycled — idle timeout, or its use limit — and when orvad restarts,
+because the signing key is random per process. Restarting invalidates every
+credential for every function at once, which is the bigger hammer if you want
+one.
+
+Redeploying used not to be enough: the credential was derived from the function
+ID alone, so the deploy meant to remove a compromised dependency re-minted the
+stolen token byte-identical, and only a restart cleared it. Each credential now
+also names the specific worker process it was issued to.
 
 Then check that function's Schedules page for anything you did not create
 (schedules added by the SDK carry a name and are badged as such) and its KV


### PR DESCRIPTION
Closes the last open item from the credential-architecture panel — and the one place where the documentation was correct only because the behaviour was wrong.

## The bug

`ORVA_INTERNAL_TOKEN` was `HMAC(process key, function id)` and nothing else. The function ID doesn't change, so the credential was **identical across deploys**.

A compromised npm or pip dependency copies the token out of your sandbox. You find it, remove it, redeploy — and the deploy re-mints the stolen token **byte-identical**. Only restarting the whole server cleared it.

`docs/SECURITY.md` had to tell operators to restart orvad, because "remove the dependency and redeploy" — the instinct every other platform trains — silently didn't work. That's the shape I wouldn't leave to prose: the person who needs that sentence is mid-incident and not reading the security page.

## The fix

The mismatch was one of lifetimes. The credential named a **function**, which is permanent; the thing legitimately holding it is a **deployed version**, which is not.

`Mint` now adds a 16-byte per-spawn nonce and returns a `release`; `Verify` requires that nonce to still be live. Redeploy retires a function's warm workers, each worker's nonce dies with its process, and the stolen copy stops working. Blast radius: **a process lifetime → a worker lifetime**.

## Where the release is wired, and why

Into the reaper goroutine in `sandbox/worker.go`, via a new `ExecConfig.OnExit`. **Deliberately not** `Kill` or `retirePool` — those express an *intention* to stop a worker, and a busy one keeps serving until it drains, so releasing there would 401 a live request. The reaper is the only place the process is known gone, and it sees every exit path: clean quit, SIGKILL, child crash, ctx cancel.

It remains the only `cmd.Wait()` in the package, per CONTRACT §9 — this adds *to* that goroutine rather than adding a second `Wait`.

Failure directions are asymmetric on purpose:
- **A missed release** leaks one map entry and degrades to exactly the old behaviour. That's why the pool also releases on both spawn error paths — the fail-closed egress return (which exits from the middle of the closure) and a failed `Spawn`.
- **A premature release** would be an outage, and cannot happen from a post-mortem hook.

v1 tokens are dropped rather than kept for compatibility: the signing key is process-random, so no credential survives the restart that deploys a new binary anyway.

## Verification — each test fails without its own piece

| Remove | Result |
|---|---|
| the reaper hook | credential still valid **5s after its worker died** |
| the release on the egress error path | credential valid for a worker that **never started** |
| the nonce check in `Verify` | 4 sdkauth cases fail |

The reaper path is exercised **locally against a real spawned-and-killed worker**, not deferred to the sandbox E2E — the fake-sandbox harness in `pool` produces a live process, so the test kills it and polls for the release.

`go vet` + `go test ./...`, `-race` clean on `sdkauth`, `pool`, `sandbox`, `server`.

## Docs

`SECURITY.md` now says remove-and-redeploy, and records what the old behaviour was so the change is legible. `backend/CLAUDE.md`'s `sdkauth` row states the new lifetime and adds an invariant: the release is wired to the reaper, not to `Kill`, and why. CHANGELOG under **Fixed** — nothing to do on upgrade, since every worker is replaced when you restart into the new version.