### PR TITLE
docs(changelog): cut v2026.08.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ upgrading to.**
 
 Entries describe what changes *for an operator*. Implementation detail lives in
 the commit messages. Only the current release's tag exists — older tags are
-pruned with their releases — so `git log v2026.08.25..HEAD` is the range for
+pruned with their releases — so `git log v2026.08.26..HEAD` is the range for
 anything unreleased, and the sections below are the record for everything
 before it.
 
 ## Unreleased
+
+Nothing yet.
+
+## v2026.08.26
+
+One security fix, and a documentation correction large enough to matter on its
+own. Nothing here asks anything of an operator: no migration, no configuration
+change, no re-issued credentials.
 
 ### Fixed
 
@@ -31,6 +39,49 @@ before it.
 
   Nothing to do on upgrade: credentials are minted at spawn and every worker is
   replaced when you restart into the new version.
+
+- **The documentation now matches the code.** An audit compared every document
+  against the source and found 181 defects, 81 of them factually wrong. The
+  ones you were most likely to hit:
+
+  - The handler contract described `event.body` as parsed JSON. It has always
+    been a raw string, so both headline examples in the reference were broken —
+    the Python one returned HTTP 500, the Node one silently answered the wrong
+    thing. Corrected, and the examples were executed rather than read.
+  - The in-product AI assistant was prompted with an API that partly does not
+    exist (`event.path_params`, an `x-orva-base64` response flag,
+    `jobs.enqueue(delay_seconds=…)`, `auth_mode: "public"`), so it generated
+    handlers that could not run.
+  - `RUNTIMES.md` said dependency installs run on the host. They run inside
+    nsjail.
+  - The recovery procedure for a lost admin key deleted your accounts and
+    recovered nothing.
+  - The backup procedure omitted `.master.key`, without which restored secrets
+    are undecryptable ciphertext.
+  - `docker compose up -d` could not work from the downloaded compose file, and
+    the README never mentioned Compose publishes on port 3000.
+
+  Documentation is now part of a change rather than a follow-up: `CONTRACT.md`
+  §6a requires docs to move in the same commit as the code, with a table of
+  what to update for what.
+
+### Verified
+
+Beyond CI's gate (`test/e2e/run.py` with `ORVA_REQUIRE_SANDBOX=1` on amd64 and
+arm64, the server and CLI installers, native systemd, docker smoke, CodeQL):
+
+- **Every regression test was run against the unfixed code and shown to fail
+  first.** For the credential fix that meant three separate proofs: removing
+  the reaper hook leaves a credential valid five seconds after its worker died,
+  removing the release from the spawn error path leaves one valid for a worker
+  that never started, and removing the nonce check fails four `sdkauth` cases.
+- **The reaper path was exercised locally** against a real spawned-and-killed
+  worker, rather than relying on the sandbox E2E alone.
+- **`go test -race`** on `sdkauth`, `pool`, `sandbox` and `server`.
+
+Not run: `test/atscale.sh` and the migration rehearsal. Neither is implicated —
+no pool sizing, scheduler or migration behaviour changed — but CONTRACT §6 lists
+them as beyond CI, so their absence is stated rather than implied.
 
 ## v2026.08.25
 


### PR DESCRIPTION
Release prep. `CHANGELOG.md` only, nothing tagged by this PR.

## What's in it

**One security fix.** Redeploying a function now invalidates a leaked `ORVA_INTERNAL_TOKEN`. It previously did not — the credential was derived from the function ID alone, so the deploy meant to remove a compromised dependency re-minted the stolen token byte-identical. The documented remediation looked like it worked and didn't.

**One documentation entry**, which normally wouldn't earn a changelog line. 81 of 181 audited defects were factually wrong, and several were the kind a reader *acts on*: a handler contract that made both headline examples in the reference fail (HTTP 500 on Python, silently wrong on Node), an AI assistant prompted with an API that partly doesn't exist, a lost-admin-key recovery that deletes your accounts and recovers nothing, and a backup procedure omitting `.master.key` — without which restored secrets are undecryptable ciphertext. Anyone who read those and acted on them deserves to know they changed.

## Verified section

Records the fail-first proofs rather than the outcome. For the credential fix that's three separate ones: removing the reaper hook leaves a credential valid **five seconds after its worker died**; removing the release from the spawn error path leaves one valid for a worker that **never started**; removing the nonce check fails four `sdkauth` cases.

It also names what was **not** run — `test/atscale.sh` and the migration rehearsal — since CONTRACT §6 lists them as beyond CI. Neither is implicated: no pool sizing, scheduler or migration behaviour changed.

## Operator impact

None. No migration, no configuration change, no re-issued credentials, no breaking changes.

## After this merges

The tag goes on this PR's merge commit once its `main` CI is green, since `release.yml`'s gate checks that exact SHA. Then `v2026.08.25` gets pruned — **after** the new release is live, never before, or `latest` 404s for every installer in the gap.