### PR TITLE
One picker, one ladder, and a suite that sees pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,77 @@ before it.
 
 ## Unreleased
 
-Nothing yet.
+### Changed
+
+- **One control, drawn one way, everywhere.** The dashboard had reached nine
+  corner radii, `Refresh` at three heights with three icon sizes across six
+  views, `Cancel` as a ghost button on seven screens and a secondary button on
+  five, and `Copy secret` rendered four different ways in four places. Each of
+  those was individually defensible and the set was not. Radii are down to five
+  values from nine, every control sits on the size ladder, and a label that
+  appears in two views is now the same control in both.
+
+- **Every picker is the dashboard's own control, not the phone's.** Fifteen
+  fields were still native `<select>`s, which hand a phone its operating-system
+  wheel — several of them sitting beside a control that opened a panel instead,
+  so two fields in the same form behaved differently. All of them are now one
+  picker: a type-ahead box once a list runs long (which the timezone and
+  template lists needed), grouped headings where the list had them, and a bottom
+  sheet on a phone rather than a dropdown too small to hit.
+
+- **Dialogs are sheets on a phone.** A modal used to be the desktop dialog with
+  its margins turned down: a bordered, fully rounded card floating against the
+  top of the screen, which is the one presentation a phone has no idiom for. It
+  now rises from the bottom edge with a grab handle, where the thumb already is,
+  and every overlay in the product behaves the same way.
+
+### Fixed
+
+- **Filter strips no longer drag the page sideways.** Swiping a horizontal strip
+  that had reached its end pulled the whole page with it, so the layout slid
+  diagonally and settled back. The strips stop at their ends now, and the page
+  itself does not pan.
+
+- **Buttons no longer flicker when tapped.** The colour transition on 117
+  controls also animated three gradient properties, which some mobile browsers
+  repaint in full rather than interpolate.
+
+- **The mobile drawer draws one line, not two.** Its header rule sat a few
+  pixels below the top bar's, and a vertical edge crossed both.
+
+- **Expandable sections look expandable.** Five of them had four different
+  affordances, and two — the egress policy detail and a trace's structured
+  attributes — had none at all and read as plain text. All five now carry the
+  same chevron.
+
+- **Smaller things that were visibly inconsistent.** Two fields in the same form
+  had different fills; button labels and page headings were split between
+  sentence case and Title Case; one cron form mixed two label styles; the
+  invocations search box was squeezed to three characters by the filter chips
+  beside it on a phone; the DNS search-domain field clipped its own placeholder;
+  and the docs Copy button was a lone unlabelled square on a phone.
+
+### Verified
+
+- **A new `consistency` browser suite makes this stick.** Every other check in
+  the suite measures a control against a standard, which is how the drift above
+  survived 2520 passing assertions: `Function` at 26.6px passed, `STATUS` at
+  26.6px passed, and that one was 10px uppercase beside the other at 11.4px
+  sentence-case was invisible to both. The new suite asserts three relational
+  facts instead — controls sharing a row agree on height, label size, case and
+  radius; a label that appears in two views is drawn the same way in both; and
+  the radius and icon-size populations stay inside a declared set. It found real
+  drift on its first run, and each of its three checks has been shown to fail on
+  a defect before being trusted to pass.
+
+- **2668 checks, zero failures**, across 19 routes x 7 viewports x both themes,
+  run against the embedded binary rather than the dev server — Vite serves
+  source and the binary serves a bundle with different CSS ordering. `go vet`
+  clean, 25 Go packages green, 53 frontend unit tests green.
+
+- **Looked at, not only measured.** Every fix above the test suites could not
+  see — a squeezed search box, two fields with different fills, a disclosure
+  with no affordance — was found by reading screenshots of the running product.
 
 ## v2026.08.27
 

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -260,4 +260,10 @@ never been executed.
 - Vue: Composition API + `<script setup>` only; Pinia for state (no Vuex, no Options API
   in new code).
 - Handlers respond via `respond.JSON` / `respond.Error` (`backend/internal/server/handlers/respond/`).
-- Comments explain the **why**, not the **what**.
+- Comments explain the **why**, not the **what** — and they have a **budget**.
+  Default to none. One line when warranted, two at most. A block comment has to
+  earn itself: a real trap, a prior attempt someone would otherwise repeat, or a
+  number that came from a measurement. Never narrate history a commit message
+  already carries, and never restate the diff in prose above the diff. "Explain
+  the why" alone was not enough — it was obeyed while one-line changes grew
+  eight-line essays.

--- a/backend/internal/mcp/reference.md
+++ b/backend/internal/mcp/reference.md
@@ -1285,7 +1285,7 @@ Failed deliveries (non-2xx, timeout, network) retry up to 5× with exponential b
 <auth_modes>
 Configure auth_mode on the function record (editor Settings modal or PUT /api/v1/functions/<name>):
 - "none" (default) — anyone with the URL can invoke. If the function needs user auth, verify a JWT IN the handler. (The accepted values are "none", "platform_key" and "signed"; there is no "public".)
-- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API Keys page.
+- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API keys page.
 - "signed" — caller signs the request with HMAC-SHA256 over "<unix-timestamp>.<raw_body>" using ORVA_SIGNING_SECRET (a function secret). Headers: X-Orva-Timestamp, X-Orva-Signature: sha256=<hex>. ±5 min skew window. Use for partner integrations where you've shared a secret and want pure HTTP without OAuth.
 
 For end-user apps prefer in-handler JWT verification (Auth0, Clerk, Supabase, Firebase) — the platform stays out of the way. Pattern in Python:
@@ -1448,7 +1448,7 @@ def handler(event):
             "body": {"deleted": deleted}}
 ```
 
-Wire it up: enable outbound network, then open Schedules → New Schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
+Wire it up: enable outbound network, then open Schedules → New schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
 </your_response>
 </example_2_cron_cleanup>
 

--- a/cli/commands/reference.md
+++ b/cli/commands/reference.md
@@ -1285,7 +1285,7 @@ Failed deliveries (non-2xx, timeout, network) retry up to 5× with exponential b
 <auth_modes>
 Configure auth_mode on the function record (editor Settings modal or PUT /api/v1/functions/<name>):
 - "none" (default) — anyone with the URL can invoke. If the function needs user auth, verify a JWT IN the handler. (The accepted values are "none", "platform_key" and "signed"; there is no "public".)
-- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API Keys page.
+- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API keys page.
 - "signed" — caller signs the request with HMAC-SHA256 over "<unix-timestamp>.<raw_body>" using ORVA_SIGNING_SECRET (a function secret). Headers: X-Orva-Timestamp, X-Orva-Signature: sha256=<hex>. ±5 min skew window. Use for partner integrations where you've shared a secret and want pure HTTP without OAuth.
 
 For end-user apps prefer in-handler JWT verification (Auth0, Clerk, Supabase, Firebase) — the platform stays out of the way. Pattern in Python:
@@ -1448,7 +1448,7 @@ def handler(event):
             "body": {"deleted": deleted}}
 ```
 
-Wire it up: enable outbound network, then open Schedules → New Schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
+Wire it up: enable outbound network, then open Schedules → New schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
 </your_response>
 </example_2_cron_cleanup>
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -248,7 +248,7 @@ if the row ever goes missing.
 
 **If the keyfile is genuinely gone**, the plaintext is unrecoverable: the
 database stores only its SHA-256. Sign in to the dashboard with your operator
-account and mint a fresh key from Settings → API Keys (or
+account and mint a fresh key from Settings → API keys (or
 `POST /api/v1/keys`). Deleting the keyfile alone does **not** make Orva
 generate a new one — it regenerates only when the database has no keys at all.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -92,7 +92,7 @@ its own place to revoke it:
 
 | Class | Grants | Revoke at |
 |---|---|---|
-| **API keys** | full instance management | Settings → API Keys |
+| **API keys** | full instance management | Settings → API keys |
 | **Channel tokens** | MCP only, invoke only, over a named set of functions — and they bypass those functions' `auth_mode` by design | Channels page |
 | **OAuth grants** | issued to a connected application (claude.ai, ChatGPT) through the consent screen | Settings → Connected applications |
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1285,7 +1285,7 @@ Failed deliveries (non-2xx, timeout, network) retry up to 5× with exponential b
 <auth_modes>
 Configure auth_mode on the function record (editor Settings modal or PUT /api/v1/functions/<name>):
 - "none" (default) — anyone with the URL can invoke. If the function needs user auth, verify a JWT IN the handler. (The accepted values are "none", "platform_key" and "signed"; there is no "public".)
-- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API Keys page.
+- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API keys page.
 - "signed" — caller signs the request with HMAC-SHA256 over "<unix-timestamp>.<raw_body>" using ORVA_SIGNING_SECRET (a function secret). Headers: X-Orva-Timestamp, X-Orva-Signature: sha256=<hex>. ±5 min skew window. Use for partner integrations where you've shared a secret and want pure HTTP without OAuth.
 
 For end-user apps prefer in-handler JWT verification (Auth0, Clerk, Supabase, Firebase) — the platform stays out of the way. Pattern in Python:
@@ -1448,7 +1448,7 @@ def handler(event):
             "body": {"deleted": deleted}}
 ```
 
-Wire it up: enable outbound network, then open Schedules → New Schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
+Wire it up: enable outbound network, then open Schedules → New schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
 </your_response>
 </example_2_cron_cleanup>
 

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -93,6 +93,7 @@ re-declaring tokens flips the app without touching markup.
 | `components/common/RuntimeTag.vue` | The one place a runtime is drawn. Renders the mark **icon-only** with the word in the accessible name and tooltip: in a dense list the glyph resolves faster than the text, and the set is two items wide, stable, and has marks operators already know. Pass `withLabel` where the operator is *choosing* a runtime rather than recognising one. Icon-only is deliberately **not** applied to status, which keeps its word. |
 | `components/layout/BrandLockup.vue` | One logo + wordmark lockup, used by both the mobile top bar and the drawer header so the two cannot drift apart. |
 | `composables/useMenuFocus.js` | Shared focus handling for menu-style popovers. |
+| `components/common/FilterSelect.vue` | The **only** picker. There are no native `<select>`s left and `test/responsive.test.js` fails the build if one comes back: a `<select>` opens the OS wheel on a phone while everything beside it opens a sheet. Three shapes — a filter chip (default), `wide` for a form field, `bare` for a dense inline bar. An option with `header: true` is a group heading. |
 | `components/common/Button.vue` | `variant` covers primary / secondary / danger / ghost / chip. The `danger` fill uses `--color-danger-solid`, which is darker than `--color-danger`: white on the lighter red measures 3.76:1 and misses AA. Use the lighter red for text, borders and tints; the solid one only behind white text. |
 
 **`text-link` for inline links, never `text-primary`**, which is for icons and

--- a/frontend/public/docs.md
+++ b/frontend/public/docs.md
@@ -1285,7 +1285,7 @@ Failed deliveries (non-2xx, timeout, network) retry up to 5× with exponential b
 <auth_modes>
 Configure auth_mode on the function record (editor Settings modal or PUT /api/v1/functions/<name>):
 - "none" (default) — anyone with the URL can invoke. If the function needs user auth, verify a JWT IN the handler. (The accepted values are "none", "platform_key" and "signed"; there is no "public".)
-- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API Keys page.
+- "platform_key" — caller must send X-Orva-API-Key: <key>  OR  Authorization: Bearer <key>, OR be in the Orva session cookie. The key must carry the "invoke" permission; a key scoped to read/write only gets 403. Keys minted from the CLI, the bootstrap flow and OAuth carry it; the dashboard's key form now has a permission selector (default invoke+read), so a dashboard key can be minted without it. Use for server-to-server, CI deploys, internal dashboards, cron-triggered functions invoked from elsewhere. Mint keys from the API keys page.
 - "signed" — caller signs the request with HMAC-SHA256 over "<unix-timestamp>.<raw_body>" using ORVA_SIGNING_SECRET (a function secret). Headers: X-Orva-Timestamp, X-Orva-Signature: sha256=<hex>. ±5 min skew window. Use for partner integrations where you've shared a secret and want pure HTTP without OAuth.
 
 For end-user apps prefer in-handler JWT verification (Auth0, Clerk, Supabase, Firebase) — the platform stays out of the way. Pattern in Python:
@@ -1448,7 +1448,7 @@ def handler(event):
             "body": {"deleted": deleted}}
 ```
 
-Wire it up: enable outbound network, then open Schedules → New Schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
+Wire it up: enable outbound network, then open Schedules → New schedule → expression `0 3 * * *`, timezone UTC, function this one. Set auth_mode to platform_key on the function so the URL can't be triggered manually by random callers.
 </your_response>
 </example_2_cron_cleanup>
 

--- a/frontend/src/components/ai/AISettingsPanel.vue
+++ b/frontend/src/components/ai/AISettingsPanel.vue
@@ -28,20 +28,19 @@
             for="ai-active-provider"
             class="text-xs font-medium text-foreground-muted uppercase tracking-wide"
           >Active provider</label>
-          <select
-            id="ai-active-provider"
-            :value="store.selectedProviderId || ''"
-            class="mt-1.5 h-10 w-full bg-background border border-border rounded-md text-sm px-3 text-foreground transition-colors duration-200 focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-            @change="onSelectProvider"
-          >
-            <option
-              v-for="p in store.providers"
-              :key="p.id"
-              :value="p.id"
-            >
-              {{ p.label ? `${p.provider} (${p.label})` : p.provider }}
-            </option>
-          </select>
+          <!-- The model field beside this one is a Popover; this was a native
+               <select>. Two identical-looking fields in matching grid cells,
+               one opening the OS wheel and one a panel. -->
+          <div class="mt-1.5">
+            <FilterSelect
+              trigger-id="ai-active-provider"
+              :options="providerOptions"
+              :model-value="store.selectedProviderId || ''"
+              label="Active provider"
+              wide
+              @update:model-value="onSelectProviderId"
+            />
+          </div>
         </div>
         <div>
           <label
@@ -121,12 +120,12 @@
 
     <!-- Add / update provider -->
     <details class="group border-t border-border pt-4">
-      <summary class="flex cursor-pointer list-none items-center justify-between rounded-sm text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
-        Add provider
-        <span
-          class="text-foreground-muted transition-transform group-open:rotate-45"
+      <summary class="flex cursor-pointer list-none items-center gap-1.5 rounded-md text-sm font-semibold text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
+        <ChevronRight
+          class="w-3.5 h-3.5 shrink-0 transition-transform group-open:rotate-90 text-foreground-muted"
           aria-hidden="true"
-        >+</span>
+        />
+        Add provider
       </summary>
       <div class="mt-4 space-y-3">
         <p class="text-xs text-foreground-muted max-w-prose leading-snug">
@@ -137,19 +136,15 @@
             for="ai-provider"
             class="text-xs font-medium text-foreground-muted uppercase tracking-wide"
           >Provider</label>
-          <select
-            id="ai-provider"
-            v-model="form.provider"
-            class="mt-1.5 h-10 w-full bg-background border border-border rounded-md text-sm px-3 text-foreground transition-colors duration-200 focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-          >
-            <option
-              v-for="opt in PROVIDERS"
-              :key="opt"
-              :value="opt"
-            >
-              {{ opt }}
-            </option>
-          </select>
+          <div class="mt-1.5">
+            <FilterSelect
+              v-model="form.provider"
+              :options="providerKindOptions"
+              label="Provider"
+              trigger-id="ai-provider"
+              wide
+            />
+          </div>
         </div>
         <Input
           v-model="form.label"
@@ -264,6 +259,8 @@
 
 <script setup>
 import { ref, computed, onMounted } from 'vue'
+import { ChevronRight } from '@lucide/vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import Button from '@/components/common/Button.vue'
 import Input from '@/components/common/Input.vue'
 import ModelMenu from '@/components/ai/ModelMenu.vue'
@@ -341,6 +338,16 @@ onMounted(async () => {
   await store.loadSettings()
   await store.loadProviders()
 })
+
+// The picker emits a value; the existing handler reads an event target. Adapt
+// here rather than rewriting the handler, which also serves nothing else.
+const providerKindOptions = PROVIDERS.map((opt) => ({ value: opt, label: opt }))
+const providerOptions = computed(() => (store.providers || []).map((p) => ({
+  value: p.id,
+  label: p.label ? `${p.provider} (${p.label})` : p.provider,
+})))
+
+const onSelectProviderId = (id) => onSelectProvider({ target: { value: id } })
 
 async function onSelectProvider(event) {
   await store.selectProvider(event.target.value)

--- a/frontend/src/components/ai/CodeBlock.vue
+++ b/frontend/src/components/ai/CodeBlock.vue
@@ -127,7 +127,7 @@ async function onCopy() {
   padding: 0.25rem 0.55rem;
   background: var(--color-background);
   border: 1px solid var(--color-border);
-  border-radius: 0.35rem;
+  border-radius: var(--radius-md);
   color: var(--color-foreground-muted);
   font-family: var(--font-sans);
   font-size: 11px;
@@ -190,6 +190,7 @@ async function onCopy() {
   font-size: 11px;
   cursor: pointer;
   transition: color 120ms, background 120ms;
+  border-radius: var(--radius-md);
 }
 .cb-expand:hover {
   color: var(--color-foreground);

--- a/frontend/src/components/ai/Composer.vue
+++ b/frontend/src/components/ai/Composer.vue
@@ -52,7 +52,7 @@
             title="Send message"
             @click="submit"
           >
-            <ArrowUp class="h-4 w-4" />
+            <ArrowUp class="h-3.5 w-3.5" />
           </button>
         </div>
       </div>

--- a/frontend/src/components/ai/ConversationRail.vue
+++ b/frontend/src/components/ai/ConversationRail.vue
@@ -35,7 +35,7 @@
         :class="c.id === store.activeId ? 'bg-primary/15' : 'hover:bg-surface-hover'"
       >
         <button
-          class="touch-expand-sm flex min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+          class="touch-expand-sm flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
           :class="c.id === store.activeId ? 'text-foreground-strong' : 'text-foreground-muted group-hover:text-foreground-strong'"
           :aria-current="c.id === store.activeId ? 'page' : undefined"
           @click="onOpen(c.id)"
@@ -45,7 +45,7 @@
         </button>
         <button
           type="button"
-          class="touch-expand-iconbtn shrink-0 rounded-md p-2 text-foreground-muted opacity-0 transition-opacity hover:bg-surface-hover hover:text-foreground-strong focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary group-hover:opacity-100 max-md:opacity-100"
+          class="touch-expand-iconbtn inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-foreground-muted opacity-0 transition-opacity hover:bg-surface-hover hover:text-foreground-strong focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary group-hover:opacity-100 max-md:opacity-100"
           title="Rename conversation"
           aria-label="Rename conversation"
           @click.stop="onRename(c)"
@@ -54,7 +54,7 @@
         </button>
         <button
           type="button"
-          class="touch-expand-iconbtn shrink-0 rounded-md p-2 text-foreground-muted opacity-0 transition-opacity hover:bg-surface-hover hover:text-danger-fg focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary group-hover:opacity-100 max-md:opacity-100"
+          class="touch-expand-iconbtn inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-foreground-muted opacity-0 transition-opacity hover:bg-surface-hover hover:text-danger-fg focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary group-hover:opacity-100 max-md:opacity-100"
           title="Delete conversation"
           aria-label="Delete conversation"
           @click.stop="onDelete(c.id)"

--- a/frontend/src/components/ai/ModelMenu.vue
+++ b/frontend/src/components/ai/ModelMenu.vue
@@ -16,7 +16,7 @@
         type="button"
         class="inline-flex items-center gap-1.5 transition-colors focus-visible:outline-none"
         :class="wide
-          ? 'h-10 w-full justify-between rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-surface-hover focus-visible:border-focus-ring focus-visible:ring-1 focus-visible:ring-focus-ring'
+          ? 'touch-expand-md h-10 w-full justify-between rounded-md border border-border bg-background px-3 text-sm text-foreground hover:bg-surface-hover focus-visible:border-focus-ring focus-visible:ring-1 focus-visible:ring-focus-ring'
           : 'touch-expand-sm h-8 max-w-[min(24rem,48vw)] rounded-lg px-2.5 text-xs text-foreground-muted hover:text-foreground hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-surface'"
         :title="store.selectedModel || 'Select model'"
         aria-label="Select model"

--- a/frontend/src/components/ai/ReasoningMenu.vue
+++ b/frontend/src/components/ai/ReasoningMenu.vue
@@ -29,7 +29,7 @@
         :aria-expanded="open"
         @click="toggle"
       >
-        <Brain class="w-4 h-4 shrink-0" />
+        <Brain class="w-3.5 h-3.5 shrink-0" />
         <span v-if="active">{{ currentLabel }}</span>
       </button>
     </template>

--- a/frontend/src/components/channels/FunctionPickerModal.vue
+++ b/frontend/src/components/channels/FunctionPickerModal.vue
@@ -110,7 +110,7 @@
         </div>
         <div class="flex gap-2">
           <Button
-            variant="secondary"
+            variant="ghost"
             @click="$emit('close')"
           >
             Cancel

--- a/frontend/src/components/common/Button.vue
+++ b/frontend/src/components/common/Button.vue
@@ -92,10 +92,10 @@ const sizeClasses = computed(() => {
   // and the page-header CTA on every view — needs expanding too. It was
   // previously left out on the assumption that 40 px was already compliant.
   switch (props.size) {
-    case 'xs': return 'h-7 px-2.5 text-xs touch-expand-xs'
-    case 'sm': return 'h-8 px-3 text-xs touch-expand-sm'
-    case 'lg': return 'h-12 px-6 text-base'
-    default:   return 'h-10 px-4 text-sm touch-expand-md'
+    case 'xs': return 'h-7 px-2.5 text-xs touch-expand-xs btn-ico-xs'
+    case 'sm': return 'h-8 px-3 text-xs touch-expand-sm btn-ico-sm'
+    case 'lg': return 'h-12 px-6 text-base btn-ico-lg'
+    default:   return 'h-10 px-4 text-sm touch-expand-md btn-ico-md'
   }
 })
 

--- a/frontend/src/components/common/CommandPalette.vue
+++ b/frontend/src/components/common/CommandPalette.vue
@@ -151,7 +151,7 @@ const items = [
   { id: 'go-cron',     label: 'Schedules',         icon: CalendarClock,action: () => router.push('/cron') },
   { id: 'go-activity', label: 'Activity',          icon: Activity,     action: () => router.push('/activity') },
   { id: 'go-traces',   label: 'Traces',            icon: Network,      action: () => router.push('/traces') },
-  { id: 'go-keys',     label: 'API Keys',          icon: Fingerprint,  action: () => router.push('/api-keys') },
+  { id: 'go-keys',     label: 'API keys',          icon: Fingerprint,  action: () => router.push('/api-keys') },
   { id: 'go-channels', label: 'Channels',          icon: Plug,         action: () => router.push('/channels') },
   { id: 'go-hooks',    label: 'Webhooks',          icon: Webhook,      action: () => router.push('/webhooks') },
   // keywords keeps this reachable by its old name; the page was "Firewall"

--- a/frontend/src/components/common/ConfirmDialog.vue
+++ b/frontend/src/components/common/ConfirmDialog.vue
@@ -72,7 +72,7 @@
           <div class="flex flex-col-reverse sm:flex-row sm:justify-end gap-2 pt-2">
             <Button
               v-if="!confirm.noticeOnly"
-              variant="secondary"
+              variant="ghost"
               class="w-full sm:w-auto"
               @click="confirm.settle(false)"
             >

--- a/frontend/src/components/common/FilterSelect.vue
+++ b/frontend/src/components/common/FilterSelect.vue
@@ -1,0 +1,172 @@
+<template>
+  <!--
+    FilterSelect — the app's only picker. A native <select> hands a phone its OS
+    wheel, which is fine alone and wrong beside a control that opens a sheet.
+
+    Built on Popover, not a bare absolute panel: every filter strip here is an
+    overflow-x scroller, so an absolutely positioned menu is clipped by its own
+    toolbar, and Popover teleports out and becomes a bottom sheet below sm.
+
+    Long lists get a type-ahead box — the one thing a <select> was better at.
+  -->
+  <Popover
+    :title="label"
+    :wide="wide"
+  >
+    <template #trigger="{ open, toggle }">
+      <!-- The filled state says "a filter is applied", so a wide picker never
+           wears it: a form field always has a value and would read as pinned
+           on, beside an outlined field of the same role. -->
+      <button
+        :id="triggerId"
+        ref="triggerRef"
+        type="button"
+        :disabled="disabled"
+        :class="[
+          'touch-expand-xs inline-flex items-center gap-1.5 rounded-md border transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          wide
+            ? 'h-10 w-full justify-between px-3 text-sm touch-expand-md'
+            : 'h-7 px-2.5 text-xs',
+          bare && 'font-mono',
+          active && !wide
+            ? 'border-primary bg-primary text-primary-foreground'
+            : wide
+              ? 'border-border bg-background text-foreground hover:border-foreground-muted'
+              : 'border-border bg-surface text-foreground-muted hover:text-foreground-strong hover:border-foreground-muted',
+        ]"
+        :aria-haspopup="'menu'"
+        :aria-expanded="open ? 'true' : 'false'"
+        @click="toggle"
+      >
+        <span
+          v-if="!wide && !bare"
+          class="text-[10px] uppercase tracking-wider"
+        >{{ label }}{{ active ? ':' : '' }}</span>
+        <span
+          v-if="active || wide || bare"
+          class="min-w-0 truncate"
+        >{{ activeLabel }}</span>
+        <ChevronDown
+          :class="wide ? 'h-3.5 w-3.5 shrink-0 opacity-70' : 'h-3 w-3 shrink-0 opacity-60'"
+          aria-hidden="true"
+        />
+      </button>
+    </template>
+
+    <template #default="{ close }">
+      <!-- The filter box earns its place past a handful of options; below that
+           it is a keyboard trap between the trigger and the first row. -->
+      <div
+        v-if="options.length > SEARCH_AT"
+        class="sticky top-0 z-10 bg-background px-2 pb-2 pt-2"
+      >
+        <input
+          v-model="query"
+          type="text"
+          :placeholder="`Filter ${label.toLowerCase()}`"
+          class="h-8 w-full rounded-md border border-border bg-background px-2.5 text-xs text-foreground placeholder-foreground-muted focus:border-focus-ring focus:outline-none focus:ring-1 focus:ring-focus-ring"
+          :aria-label="`Filter ${label.toLowerCase()}`"
+        >
+      </div>
+
+      <div
+        class="max-h-72 overflow-y-auto scrollable py-1"
+        role="none"
+      >
+        <template
+          v-for="opt in shown"
+          :key="opt.header ? `h-${opt.label}` : opt.value"
+        >
+          <p
+            v-if="opt.header"
+            class="px-3 pb-1 pt-2 text-[10px] uppercase tracking-wider text-foreground-muted"
+          >
+            {{ opt.label }}
+          </p>
+          <button
+            v-else
+            type="button"
+            role="menuitemradio"
+            :aria-checked="opt.value === modelValue ? 'true' : 'false'"
+            :disabled="opt.disabled"
+            class="touch-expand-sm flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm text-foreground transition-colors hover:bg-surface-hover disabled:cursor-not-allowed disabled:opacity-40"
+            @click="pick(opt.value, close)"
+          >
+            <Check
+              class="h-3.5 w-3.5 shrink-0"
+              :class="opt.value === modelValue ? 'opacity-100' : 'opacity-0'"
+              aria-hidden="true"
+            />
+            <span class="min-w-0 flex-1 truncate">{{ opt.label }}</span>
+          </button>
+        </template>
+
+        <p
+          v-if="!shown.length"
+          class="px-3 py-2 text-xs text-foreground-muted"
+        >
+          Nothing matches.
+        </p>
+      </div>
+    </template>
+  </Popover>
+</template>
+
+<script setup>
+defineOptions({ name: 'CommonFilterSelect' })
+
+import { ref, computed, watch } from 'vue'
+import { ChevronDown, Check } from '@lucide/vue'
+import Popover from './Popover.vue'
+
+// Below this a filter box costs more than it saves.
+const SEARCH_AT = 8
+
+const props = defineProps({
+  // [{ value, label, disabled? }], or { header: true, label } for a group
+  // heading. A value of '' is the reset row: selectable, never "active", which
+  // keeps the trigger unfilled while "All" is chosen.
+  options: { type: Array, required: true },
+  modelValue: { type: [String, Number], default: '' },
+  label: { type: String, required: true },
+  // Full-width field shape, for a form grid rather than a filter strip.
+  wide: Boolean,
+  // Chip height with no label prefix -- the value is the whole trigger, for a
+  // dense inline bar where "METHOD: GET" would not fit.
+  bare: Boolean,
+  disabled: Boolean,
+  triggerId: { type: String, default: undefined },
+})
+
+const emit = defineEmits(['update:modelValue'])
+
+const query = ref('')
+const triggerRef = ref(null)
+
+const active = computed(() =>
+  props.options.find((o) => !o.header && o.value === props.modelValue && o.value !== ''))
+
+const activeLabel = computed(() => {
+  if (active.value) return active.value.label
+  return props.options.find((o) => !o.header && o.value === props.modelValue)?.label ?? props.label
+})
+
+const shown = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return props.options
+  return props.options.filter((o) => !o.header && String(o.label).toLowerCase().includes(q))
+})
+
+const pick = (value, close) => {
+  emit('update:modelValue', value)
+  close()
+  // Focus returns to the trigger, or the next Tab starts from the top of the
+  // document -- the panel it came from no longer exists.
+  triggerRef.value?.focus?.()
+}
+
+// A stale query would silently hide options the next time it opens.
+watch(() => props.options, () => { query.value = '' })
+</script>

--- a/frontend/src/components/common/Modal.vue
+++ b/frontend/src/components/common/Modal.vue
@@ -3,29 +3,41 @@
     <transition name="fade">
       <div
         v-if="modelValue"
-        class="fixed inset-0 z-40 flex items-stretch sm:items-center justify-center overflow-y-auto bg-scrim backdrop-blur-sm pt-safe pb-safe pl-safe pr-safe p-2 sm:p-4"
+        class="fixed inset-0 z-40 flex items-end sm:items-center justify-center overflow-y-auto bg-scrim backdrop-blur-sm pt-safe pl-safe pr-safe p-0 sm:p-4"
         @click.self="close"
       >
         <!--
-          Mobile (default): the modal sits flush at the top with 8 px page
-          padding all around (sm:p-4 returns the desktop 16 px), the
-          flex container is items-stretch so the inner panel can grow
-          downward inside the safe-area-padded outer. We use 100dvh in
-          the body's max-height calc so when the on-screen keyboard
-          appears, dvh shrinks and the body's scrollable area follows;
-          no JS visualViewport listener needed.
+          Mobile (default): a bottom sheet, the same shape Drawer.vue uses.
+          It used to be a desktop dialog with the margins turned down -- a
+          bordered, fully rounded card floating against the top of the screen,
+          which is the one presentation a phone has no idiom for. Anchored to
+          the bottom edge with only the top corners rounded, it reads as a
+          sheet, it is where the thumb already is, and every overlay in the
+          product now behaves the same way.
 
-          Desktop (sm+): items-center returns; max-w sizes return; the
-          panel becomes content-sized again.
+          100dvh in the body's max-height calc means the on-screen keyboard
+          shrinks dvh and the scrollable area follows; no visualViewport
+          listener needed. pb-safe sits on the panel rather than the backdrop
+          so the sheet's own fill reaches the bottom edge of the screen
+          instead of stopping short of the home indicator.
+
+          Desktop (sm+): items-center returns, the max-w sizes return, and the
+          panel is a content-sized centred dialog again.
         -->
         <div
           ref="dialogRoot"
-          class="w-full bg-background border border-border rounded-lg shadow-xl my-0 sm:my-auto flex flex-col max-w-full"
+          class="modal-panel w-full bg-background border-t border-border rounded-t-2xl shadow-xl pb-safe my-0 flex flex-col max-w-full max-h-[92dvh] sm:my-auto sm:max-h-none sm:rounded-lg sm:border sm:pb-0"
           :class="sizeClass"
           role="dialog"
           aria-modal="true"
           :aria-labelledby="titleId"
         >
+          <!-- Grab handle: the affordance that says "this drags/dismisses"
+               on a phone. Hidden from sm up, where the shape is a dialog. -->
+          <div
+            class="mx-auto mt-2 h-1 w-9 shrink-0 rounded-full bg-border sm:hidden"
+            aria-hidden="true"
+          />
           <header class="flex items-center justify-between px-5 py-3 border-b border-border shrink-0">
             <div class="flex items-center gap-2 min-w-0">
               <component
@@ -48,7 +60,7 @@
               @click="close"
             />
           </header>
-          <div class="p-5 overflow-y-auto scrollable flex-1 max-h-[calc(100dvh-9rem)] sm:max-h-[70vh]">
+          <div class="p-5 overflow-y-auto scrollable flex-1 min-h-0 sm:max-h-[70vh]">
             <slot />
           </div>
           <footer
@@ -115,3 +127,34 @@ const onKey = (e) => {
 onMounted(() => window.addEventListener('keydown', onKey))
 onUnmounted(() => window.removeEventListener('keydown', onKey))
 </script>
+
+<style scoped>
+/* A sheet arrives from the edge it is anchored to. Without this the panel
+   fades in place, which is the one thing a bottom sheet never does on a phone
+   and the reason it read as a desktop dialog wearing a sheet's shape.
+   Transform only -- animating a layout property is banned by
+   frontend/test/responsive.test.js, and rightly: it relayouts every frame. */
+@media (max-width: 639px) {
+  .fade-enter-active .modal-panel,
+  .fade-leave-active .modal-panel {
+    transition: transform 200ms cubic-bezier(0.32, 0.72, 0, 1);
+  }
+
+  .fade-enter-from .modal-panel,
+  .fade-leave-to .modal-panel {
+    transform: translateY(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-enter-active .modal-panel,
+  .fade-leave-active .modal-panel {
+    transition: none;
+  }
+
+  .fade-enter-from .modal-panel,
+  .fade-leave-to .modal-panel {
+    transform: none;
+  }
+}
+</style>

--- a/frontend/src/components/layout/Sidebar.vue
+++ b/frontend/src/components/layout/Sidebar.vue
@@ -50,7 +50,7 @@
   <aside
     id="primary-navigation"
     ref="drawerEl"
-    class="bg-background border-r border-border flex flex-col h-full shrink-0 z-40
+    class="bg-background lg:border-r border-border flex flex-col h-full shrink-0 z-40
            w-64 lg:w-52
            fixed inset-y-0 left-0 transform transition-transform duration-150 ease-out
            lg:static lg:translate-x-0 lg:transform-none lg:transition-none
@@ -60,11 +60,15 @@
     @touchmove="onTouchMove"
     @touchend="onTouchEnd"
   >
-    <div class="h-16 flex items-center px-6 border-b border-border">
+    <!-- h-14 and no border below lg: the mobile top bar already draws a rule
+         at that exact y, and a second one 7.6px lower reads as a misalignment. -->
+    <div class="h-14 lg:h-16 flex items-center px-6 lg:border-b border-border">
       <BrandLockup />
     </div>
 
-    <nav class="flex-1 p-3 space-y-1 overflow-y-auto scrollable">
+    <!-- The drawer's vertical edge starts below the header rather than cutting
+         through it; above lg the aside carries a full-height one instead. -->
+    <nav class="flex-1 p-3 space-y-1 overflow-y-auto scrollable border-r border-border lg:border-r-0">
       <router-link
         v-for="item in primaryItems"
         :key="item.path"

--- a/frontend/src/components/traces/TraceWaterfall.vue
+++ b/frontend/src/components/traces/TraceWaterfall.vue
@@ -153,7 +153,11 @@
             v-if="row.attributes"
             class="mt-3 text-xs"
           >
-            <summary class="touch-expand-sm min-h-6 inline-flex items-center cursor-pointer text-foreground-muted hover:text-foreground-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded">
+            <summary class="touch-expand-sm min-h-6 inline-flex items-center gap-1.5 cursor-pointer list-none text-foreground-muted hover:text-foreground-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded [&::-webkit-details-marker]:hidden">
+              <ChevronRight
+                class="w-3.5 h-3.5 shrink-0 transition-transform group-open:rotate-90"
+                aria-hidden="true"
+              />
               Structured attributes
             </summary>
             <pre class="mt-1 overflow-x-auto rounded bg-background p-3 text-foreground whitespace-pre-wrap">{{ prettyJSON(row.attributes) }}</pre>
@@ -221,7 +225,11 @@
             v-if="entry.fields"
             class="mt-1"
           >
-            <summary class="touch-expand-sm min-h-6 inline-flex items-center cursor-pointer text-xs text-foreground-muted hover:text-foreground-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded">
+            <summary class="touch-expand-sm min-h-6 inline-flex items-center gap-1.5 cursor-pointer list-none text-xs text-foreground-muted hover:text-foreground-strong focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded [&::-webkit-details-marker]:hidden">
+              <ChevronRight
+                class="w-3.5 h-3.5 shrink-0 transition-transform group-open:rotate-90"
+                aria-hidden="true"
+              />
               Fields
             </summary>
             <pre class="overflow-x-auto rounded bg-background p-3 text-foreground whitespace-pre-wrap">{{ prettyJSON(entry.fields) }}</pre>

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -3,6 +3,10 @@ import { createPinia } from 'pinia'
 import App from './App.vue'
 import router from './router'
 import './style.css'
+import { installEdgeGuard } from './utils/edgeGuard'
+
+// CSS asks for this and not every engine obeys; see utils/edgeGuard.js.
+installEdgeGuard()
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -303,6 +303,9 @@ body {
 html, body {
   overflow-x: hidden;
   max-width: 100vw;
+  /* overflow-x:hidden does not stop iOS panning the visual viewport: the whole
+     page could be dragged diagonally, showing the background behind it. */
+  overscroll-behavior: none;
 }
 
 /* Overflow should be discoverable on dense operational surfaces. Keep the
@@ -310,6 +313,37 @@ html, body {
 * {
   scrollbar-width: thin;
   scrollbar-color: var(--color-border) transparent;
+}
+
+/* ...except on a horizontal strip you swipe.
+   ------------------------------------------------------------
+   The rule above is right for a vertical scroller inside a table or a code
+   block, where a quiet bar is the only clue there is more to see. It is wrong
+   for a filter-chip strip: the chips themselves are the affordance, the strip
+   is swiped rather than dragged, and a 6px bar underneath them lands like a
+   stray horizontal rule between the toolbar and the content. On a phone it
+   reads as a rendering fault rather than a scrollbar.
+
+   Opt in per strip rather than switching it off for all horizontal overflow,
+   because a wide table genuinely does want the bar. */
+.swipe-x {
+  scrollbar-width: none;
+
+  /* Stop the strip rubber-banding past its ends, and stop the gesture
+     chaining to the page behind it.
+     ------------------------------------------------------------
+     `overscroll-behavior: contain` on .scrollable prevents CHAINING but still
+     permits the local elastic bounce, so on iOS the whole strip could be
+     dragged well past its last chip and sprung back -- it reads as a loose
+     component floating over the page rather than a scroller with ends.
+     `none` is the value that suppresses the bounce itself. Chromium clamps at
+     the end either way, which is exactly why this was missed: the defect only
+     appears on a real iOS device, and a headless run reports scrollLeft
+     stopping cleanly at its maximum. */
+  overscroll-behavior-x: none;
+}
+.swipe-x::-webkit-scrollbar {
+  display: none;
 }
 ::-webkit-scrollbar {
   width: 6px;
@@ -428,6 +462,42 @@ select::-ms-expand {
   top: max(env(safe-area-inset-top, 0px), 0px);
   bottom: max(env(safe-area-inset-bottom, 0px), 0px);
 }
+
+/* ============================================================
+   transition-colors, without the gradient custom properties
+   ------------------------------------------------------------
+   Tailwind v4 compiles `transition-colors` to a list that ends with
+   --tw-gradient-from, --tw-gradient-via and --tw-gradient-to. Those are
+   REGISTERED custom properties (@property with a declared syntax), which makes
+   them animatable -- and animating a registered custom property is a known
+   repaint hazard in WebKit: it can invalidate the element's layer on every
+   transition, which is visible on a phone as a flicker for the length of the
+   transition. It is on 117 controls here.
+
+   This codebase ships no Tailwind gradient utilities at all (grep for
+   bg-gradient / gradient-to / from-[ returns nothing), so those three
+   properties transition from nothing to nothing on every hover and tap. Narrow
+   the list to the four that actually change.
+
+   Unlayered on purpose: it has to outrank the utility it is correcting.
+   ============================================================ */
+.transition-colors {
+  transition-property: color, background-color, border-color, outline-color;
+}
+
+/* ============================================================
+   Glyph size follows the button's rung
+   ------------------------------------------------------------
+   Icon size was set per call site, so it stopped correlating with the control
+   it sat in: measured across the app, 15.2 / 13.3 / 11.4px appeared on
+   controls of every height, and "Refresh" shipped all three. The size prop now
+   decides, and this is unlayered so it outranks a w-3/w-4 utility left on the
+   slotted icon.
+   ============================================================ */
+.btn-ico-xs > svg { width: 0.75rem; height: 0.75rem; }
+.btn-ico-sm > svg { width: 0.875rem; height: 0.875rem; }
+.btn-ico-md > svg { width: 1rem; height: 1rem; }
+.btn-ico-lg > svg { width: 1.125rem; height: 1.125rem; }
 
 /* ============================================================
    Touch-target hit-area expansion for sub-44px controls
@@ -555,6 +625,18 @@ select::-ms-expand {
     min-height: 44px;
   }
 
+  /* And the padding has to get out of the way of that floor. A single-line
+     field with both `min-height: 44px` and its own vertical padding leaves two
+     things deciding where the text sits, and WebKit does not reliably centre
+     the inner editor when the used height exceeds the content box -- so the
+     text rode high while the magnifier, absolutely centred against the
+     wrapper, sat at the true middle. That gap is what reads as "the search
+     icon is not in the middle". Textareas keep theirs: their text starts at
+     the top by definition. */
+  input:not([type='checkbox']):not([type='radio']) {
+    padding-block: 0;
+  }
+
   /* Checkboxes and radios are the exception this rule never had. They are
      square by nature, so a height floor with no width floor deformed them:
      the four permission boxes on API Keys rendered 13px wide by 44px tall,
@@ -579,13 +661,24 @@ select::-ms-expand {
 /* ============================================================
    Bounded scrollers — for code blocks, drawer/modal bodies,
    wide tables that need horizontal scroll inside their bounds.
-   Restores momentum on iOS (the global hidden-scrollbar rule
-   above strips visual scrollbars; this restores feel) and
-   prevents body bounce when scrolling reaches the edge.
+   Restores momentum on iOS and prevents body bounce when
+   scrolling reaches the edge.
+
+   This used to say it was restoring feel after "the global
+   hidden-scrollbar rule above strips visual scrollbars". There
+   is no such rule and there never was in this file: the global
+   rule SHOWS a 6px bar on every scroller. The comment described
+   the opposite of the code it sat next to, which is how a
+   filter-chip strip ended up with a visible bar under it that
+   nobody had chosen. `.swipe-x` is the opt-out.
    ============================================================ */
 .scrollable {
   -webkit-overflow-scrolling: touch;
+  /* contain stops the gesture chaining to the page; none additionally stops
+     the element's own elastic bounce. Horizontal strips need the second --
+     see .swipe-x above for why this only shows up on a real iOS device. */
   overscroll-behavior: contain;
+  overscroll-behavior-x: none;
 }
 
 /* ============================================================

--- a/frontend/src/utils/edgeGuard.js
+++ b/frontend/src/utils/edgeGuard.js
@@ -1,0 +1,87 @@
+// Stop horizontal scrollers rubber-banding past their ends.
+//
+// `overscroll-behavior-x: none` is the CSS answer and it is in style.css, but
+// it does not land on every engine: on iOS the filter strips could still be
+// dragged well past their last chip and sprung back, which reads as a loose
+// component floating over the page rather than a scroller with ends. The strip
+// is not moving -- the browser is painting an elastic overscroll the stylesheet
+// asked it not to.
+//
+// Chromium clamps either way, so this is invisible to a headless run. The
+// browser suite drives a real touch sequence and asserts the event is
+// cancelled, which is the part that IS observable everywhere.
+//
+// The rule: while a gesture is predominantly horizontal AND the scroller is
+// already at the end it is being pushed toward, cancel the move. Vertical
+// scrolling and every in-range horizontal scroll are untouched, so the page
+// still scrolls normally when a drag starts on a strip.
+
+const SCROLLERS = '.swipe-x, .scrollable'
+
+// Below this the gesture has not declared a direction yet; cancelling on the
+// first pixel would swallow a vertical scroll that merely started with a wobble.
+const AXIS_THRESHOLD = 6
+
+/** The nearest ancestor that actually scrolls horizontally. */
+function horizontalScroller(node) {
+  for (let el = node; el && el !== document.body; el = el.parentElement) {
+    // Duck-typed rather than `instanceof Element`: a text node has no matches.
+    if (typeof el.matches !== 'function') continue
+    if (!el.matches(SCROLLERS)) continue
+    if (el.scrollWidth - el.clientWidth > 1) return el
+  }
+  return null
+}
+
+export function installEdgeGuard(target = document) {
+  let startX = 0
+  let startY = 0
+  let scroller = null
+  let locked = null // 'x' | 'y' | null, once the gesture declares itself
+
+  const onStart = (e) => {
+    if (e.touches.length !== 1) { scroller = null; return }
+    const t = e.touches[0]
+    startX = t.clientX
+    startY = t.clientY
+    locked = null
+    scroller = horizontalScroller(e.target)
+  }
+
+  const onMove = (e) => {
+    if (!scroller || e.touches.length !== 1) return
+    const t = e.touches[0]
+    const dx = t.clientX - startX
+    const dy = t.clientY - startY
+
+    if (locked === null) {
+      if (Math.abs(dx) < AXIS_THRESHOLD && Math.abs(dy) < AXIS_THRESHOLD) return
+      locked = Math.abs(dx) > Math.abs(dy) ? 'x' : 'y'
+    }
+    if (locked !== 'x') return
+
+    const max = scroller.scrollWidth - scroller.clientWidth
+    const atStart = scroller.scrollLeft <= 0
+    const atEnd = scroller.scrollLeft >= max - 1
+
+    // dx > 0 is a drag to the right, which scrolls content toward the start.
+    if ((atStart && dx > 0) || (atEnd && dx < 0)) {
+      if (e.cancelable) e.preventDefault()
+    }
+  }
+
+  const onEnd = () => { scroller = null; locked = null }
+
+  // passive:false is the whole point -- a passive listener cannot preventDefault.
+  target.addEventListener('touchstart', onStart, { passive: true })
+  target.addEventListener('touchmove', onMove, { passive: false })
+  target.addEventListener('touchend', onEnd, { passive: true })
+  target.addEventListener('touchcancel', onEnd, { passive: true })
+
+  return () => {
+    target.removeEventListener('touchstart', onStart)
+    target.removeEventListener('touchmove', onMove)
+    target.removeEventListener('touchend', onEnd)
+    target.removeEventListener('touchcancel', onEnd)
+  }
+}

--- a/frontend/src/views/Activity.vue
+++ b/frontend/src/views/Activity.vue
@@ -20,11 +20,11 @@
           v-model="filters.q"
           aria-label="Search activity by path, summary, or actor"
           placeholder="Search path, summary, actor…"
-          class="w-full bg-background border border-border rounded-md pl-8 pr-3 py-1.5 text-base sm:text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
+          class="h-7 w-full bg-background border border-border rounded-md pl-8 pr-3 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
           @input="onSearchInput"
         >
       </div>
-      <div class="flex items-center gap-2 sm:flex-wrap overflow-x-auto sm:overflow-visible scrollable snap-x min-w-0">
+      <div class="flex items-center gap-2 sm:flex-wrap overflow-x-auto sm:overflow-visible scrollable swipe-x snap-x min-w-0">
         <Button
           v-for="opt in sourceOptions"
           :key="opt.value"
@@ -80,7 +80,7 @@
       class="mb-3"
     />
 
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list. -->
       <ul class="sm:hidden divide-y divide-border">
         <li
@@ -93,7 +93,7 @@
                the detail drawer out of reach of the keyboard entirely. -->
           <button
             type="button"
-            class="w-full text-left cursor-pointer px-4 py-3 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            class="w-full text-left cursor-pointer px-4 py-3 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             :aria-label="detailLabel(row)"
             @click="openDrawer(row)"
           >
@@ -175,7 +175,7 @@
                    bare, so the desktop cell looks exactly as it did. -->
               <button
                 type="button"
-                class="touch-expand-sm text-left rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm text-left rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :aria-label="detailLabel(row)"
                 @click.stop="openDrawer(row)"
               >

--- a/frontend/src/views/ApiKeys.vue
+++ b/frontend/src/views/ApiKeys.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
         <h1 class="text-xl font-semibold text-foreground-strong tracking-tight">
-          API Keys
+          API keys
         </h1>
         <p class="text-sm text-foreground-muted mt-1.5 max-w-prose leading-body">
           Tokens for REST and MCP clients. Secrets are shown once.
@@ -11,7 +11,7 @@
       </div>
       <Button @click="openCreate">
         <KeyRound class="w-4 h-4" />
-        New Key
+        New key
       </Button>
     </div>
 
@@ -65,7 +65,7 @@
       class="bg-background border border-border rounded-lg p-5 space-y-4"
     >
       <div class="text-sm font-semibold text-foreground-strong">
-        New API Key
+        New API key
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>
@@ -77,7 +77,7 @@
             id="api-key-name"
             v-model="newKey.name"
             placeholder="e.g. ci-deployer"
-            class="w-full bg-surface-hover border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:border-focus-ring"
+            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
           >
         </div>
         <div>
@@ -85,30 +85,13 @@
             for="api-key-expiry"
             class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
           >Expires in</label>
-          <select
-            id="api-key-expiry"
+          <FilterSelect
             v-model="newKey.expiresInDays"
-            class="w-full bg-surface-hover border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:border-focus-ring"
-          >
-            <option :value="0">
-              Never
-            </option>
-            <option :value="1">
-              1 day
-            </option>
-            <option :value="7">
-              7 days
-            </option>
-            <option :value="30">
-              30 days
-            </option>
-            <option :value="90">
-              90 days
-            </option>
-            <option :value="365">
-              1 year
-            </option>
-          </select>
+            :options="expiryOptions"
+            label="Expiry"
+            trigger-id="api-key-expiry"
+            wide
+          />
         </div>
       </div>
       <div>
@@ -164,7 +147,7 @@
           :loading="submitting"
           @click="submitCreate"
         >
-          Generate Key
+          Generate key
         </Button>
       </div>
     </div>
@@ -178,7 +161,7 @@
       class="mb-3"
     />
 
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list — name + prefix on the primary
            line, last-used + expires as secondary metadata, delete on
            the right. The desktop table returns at sm+. -->
@@ -343,6 +326,7 @@ import { KeyRound, Copy, Check, X, Trash2 } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
 import IconButton from '@/components/common/IconButton.vue'
 import LoadError from '@/components/common/LoadError.vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import { listApiKeys, createApiKey, deleteApiKey } from '@/api/endpoints'
 import { copyText } from '@/utils/clipboard'
 import { formatRelative, isExpired } from '@/utils/time'
@@ -368,6 +352,14 @@ const permissionOptions = [
   { value: 'admin', label: 'Admin', hint: 'Keys, channels, firewall, backup and restore' },
 ]
 const defaultPermissions = () => ['invoke', 'read']
+const expiryOptions = [
+  { value: 0, label: 'Never' },
+  { value: 1, label: '1 day' },
+  { value: 7, label: '7 days' },
+  { value: 30, label: '30 days' },
+  { value: 90, label: '90 days' },
+  { value: 365, label: '1 year' },
+]
 const newKey = ref({ name: '', expiresInDays: 0, permissions: defaultPermissions() })
 
 const loadKeys = async () => {

--- a/frontend/src/views/Channels.vue
+++ b/frontend/src/views/Channels.vue
@@ -48,7 +48,7 @@
       <div class="flex items-center gap-2">
         <code class="flex-1 font-mono text-sm text-foreground-strong break-all bg-surface px-3 py-2 rounded border border-border">{{ createdToken }}</code>
         <button
-          class="px-3 py-2 rounded-md border border-border bg-surface-hover hover:bg-surface text-foreground-muted hover:text-foreground-strong transition-colors flex items-center gap-1.5 text-xs"
+          class="shrink-0 px-3 py-2 rounded-md border border-border bg-surface-hover hover:bg-surface text-foreground-muted hover:text-foreground-strong transition-colors flex items-center gap-1.5 text-xs touch-expand-sm"
           @click="copyCreated"
         >
           <Check
@@ -87,7 +87,7 @@
             id="channel-name"
             v-model="newChannel.name"
             placeholder="e.g. support-bot"
-            class="w-full bg-surface-hover border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary transition-colors"
+            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
           >
         </div>
         <div>
@@ -95,24 +95,13 @@
             for="channel-expiry"
             class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
           >Expires in</label>
-          <select
-            id="channel-expiry"
+          <FilterSelect
             v-model="newChannel.expiresInDays"
-            class="w-full bg-surface-hover border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary transition-colors"
-          >
-            <option :value="0">
-              Never
-            </option>
-            <option :value="7">
-              7 days
-            </option>
-            <option :value="30">
-              30 days
-            </option>
-            <option :value="90">
-              90 days
-            </option>
-          </select>
+            :options="expiryOptions"
+            label="Expiry"
+            trigger-id="channel-expiry"
+            wide
+          />
         </div>
       </div>
       <div>
@@ -124,7 +113,7 @@
           id="channel-description"
           v-model="newChannel.description"
           placeholder="What this channel is for"
-          class="w-full bg-surface-hover border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-primary transition-colors"
+          class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
         >
       </div>
       <!-- A <label> cannot name a button, and this one pointed at nothing: it
@@ -161,17 +150,17 @@
       </div>
       <div class="flex gap-2 pt-1">
         <Button
+          variant="ghost"
+          @click="cancelCreate"
+        >
+          Cancel
+        </Button>
+        <Button
           :disabled="!canSubmit || submitting"
           :loading="submitting"
           @click="submitCreate"
         >
           Generate token
-        </Button>
-        <Button
-          variant="secondary"
-          @click="cancelCreate"
-        >
-          Cancel
         </Button>
       </div>
     </div>
@@ -181,7 +170,7 @@
          IconButton actions, and the same semantic warning/danger tokens
          for the "Never used" / "Expired" hints, so an identical state
          reads as an identical colour across the two views. -->
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list. -->
       <ul class="sm:hidden divide-y divide-border">
         <li
@@ -392,6 +381,7 @@ defineOptions({ name: 'ChannelsView' })
 import { ref, computed, onMounted } from 'vue'
 import { Plug, Boxes, Copy, Check, X, Trash2, RotateCcw, AlertCircle, Pencil } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import IconButton from '@/components/common/IconButton.vue'
 import FunctionPickerModal from '@/components/channels/FunctionPickerModal.vue'
 import {
@@ -416,6 +406,12 @@ const submitting = ref(false)
 const createError = ref('')
 const pickerOpen = ref(false)
 
+const expiryOptions = [
+  { value: 0, label: 'Never' },
+  { value: 7, label: '7 days' },
+  { value: 30, label: '30 days' },
+  { value: 90, label: '90 days' },
+]
 const newChannel = ref({
   name: '',
   description: '',

--- a/frontend/src/views/CronJobs.vue
+++ b/frontend/src/views/CronJobs.vue
@@ -3,7 +3,7 @@
     <div class="flex flex-wrap items-start justify-between gap-4">
       <div>
         <h1 class="text-xl font-semibold text-foreground-strong tracking-tight">
-          Scheduled Jobs
+          Scheduled jobs
         </h1>
         <p class="text-sm text-foreground-muted mt-1.5 max-w-prose leading-body">
           Run functions on a cron schedule.
@@ -11,7 +11,7 @@
       </div>
       <Button @click="showCreateModal = true">
         <PlusCircle class="w-4 h-4" />
-        New Schedule
+        New schedule
       </Button>
     </div>
 
@@ -23,7 +23,7 @@
       class="mb-3"
     />
 
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list. -->
       <ul class="sm:hidden divide-y divide-border">
         <li
@@ -212,7 +212,7 @@
     <!-- Create/Edit Modal -->
     <Modal
       :model-value="showCreateModal"
-      :title="editingJob ? 'Edit Schedule' : 'Create Schedule'"
+      :title="editingJob ? 'Edit schedule' : 'Create schedule'"
       size="lg"
       @update:model-value="(v) => { if (!v) closeModal() }"
     >
@@ -223,23 +223,14 @@
             for="cron-function"
             class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-2"
           >Function</label>
-          <select
-            id="cron-function"
+          <FilterSelect
             v-model="form.function_name"
-            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
+            :options="fnOptions"
             :disabled="!!editingJob"
-          >
-            <option value="">
-              Select a function
-            </option>
-            <option
-              v-for="fn in functions"
-              :key="fn.name"
-              :value="fn.name"
-            >
-              {{ fn.name }} ({{ runtimeLabel(fn.runtime) }})
-            </option>
-          </select>
+            label="Select a function"
+            trigger-id="cron-function"
+            wide
+          />
         </div>
 
         <!-- Schedule Type Tabs -->
@@ -261,7 +252,7 @@
               :aria-pressed="scheduleType === type"
               @click="scheduleType = type"
             >
-              {{ type === 'simple' ? 'Natural Language' : 'Cron Expression' }}
+              {{ type === 'simple' ? 'Natural language' : 'Cron expression' }}
             </button>
           </div>
         </div>
@@ -275,36 +266,22 @@
             <div>
               <label
                 for="cron-frequency"
-                class="text-xs font-medium text-foreground-muted block mb-1.5"
+                class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
               >Frequency</label>
-              <select
-                id="cron-frequency"
+              <FilterSelect
                 v-model="simpleSchedule.frequency"
-                class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-                @change="updateCronFromSimple"
-              >
-                <option value="minute">
-                  Every Minute
-                </option>
-                <option value="hour">
-                  Hourly
-                </option>
-                <option value="day">
-                  Daily
-                </option>
-                <option value="week">
-                  Weekly
-                </option>
-                <option value="month">
-                  Monthly
-                </option>
-              </select>
+                :options="frequencyOptions"
+                label="Frequency"
+                trigger-id="cron-frequency"
+                wide
+                @update:model-value="updateCronFromSimple"
+              />
             </div>
 
             <div v-if="['hour', 'day', 'week', 'month'].includes(simpleSchedule.frequency)">
               <label
                 for="cron-minute"
-                class="text-xs font-medium text-foreground-muted block mb-1.5"
+                class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
               >At Minute</label>
               <input
                 id="cron-minute"
@@ -320,7 +297,7 @@
             <div v-if="['day', 'week', 'month'].includes(simpleSchedule.frequency)">
               <label
                 for="cron-hour"
-                class="text-xs font-medium text-foreground-muted block mb-1.5"
+                class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
               >At Hour</label>
               <input
                 id="cron-hour"
@@ -336,42 +313,22 @@
             <div v-if="simpleSchedule.frequency === 'week'">
               <label
                 for="cron-day-of-week"
-                class="text-xs font-medium text-foreground-muted block mb-1.5"
+                class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
               >Day of Week</label>
-              <select
-                id="cron-day-of-week"
+              <FilterSelect
                 v-model="simpleSchedule.dayOfWeek"
-                class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-                @change="updateCronFromSimple"
-              >
-                <option value="0">
-                  Sunday
-                </option>
-                <option value="1">
-                  Monday
-                </option>
-                <option value="2">
-                  Tuesday
-                </option>
-                <option value="3">
-                  Wednesday
-                </option>
-                <option value="4">
-                  Thursday
-                </option>
-                <option value="5">
-                  Friday
-                </option>
-                <option value="6">
-                  Saturday
-                </option>
-              </select>
+                :options="dayOfWeekOptions"
+                label="Day of Week"
+                trigger-id="cron-day-of-week"
+                wide
+                @update:model-value="updateCronFromSimple"
+              />
             </div>
 
             <div v-if="simpleSchedule.frequency === 'month'">
               <label
                 for="cron-day-of-month"
-                class="text-xs font-medium text-foreground-muted block mb-1.5"
+                class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
               >Day of Month</label>
               <input
                 id="cron-day-of-month"
@@ -387,7 +344,7 @@
 
           <div class="bg-background border border-border rounded-lg p-4">
             <div class="text-xs font-medium text-foreground-muted uppercase tracking-wide mb-2">
-              Generated Expression
+              Generated expression
             </div>
             <div class="font-mono text-sm text-foreground">
               {{ form.cron }}
@@ -406,8 +363,8 @@
           <div>
             <label
               for="cron-expression"
-              class="text-xs font-medium text-foreground-muted block mb-1.5"
-            >Cron Expression</label>
+              class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
+            >Cron expression</label>
             <input
               id="cron-expression"
               v-model="form.cron"
@@ -441,20 +398,13 @@
           >
             Timezone
           </label>
-          <select
-            id="cron-timezone"
+          <FilterSelect
             v-model="form.timezone"
-            aria-describedby="cron-timezone-hint"
-            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-          >
-            <option
-              v-for="tz in timezoneOptions"
-              :key="tz"
-              :value="tz"
-            >
-              {{ tz }}{{ tz === detectedTZ ? '  (your browser)' : '' }}
-            </option>
-          </select>
+            :options="timezonePickerOptions"
+            label="Timezone"
+            trigger-id="cron-timezone"
+            wide
+          />
           <div
             id="cron-timezone-hint"
             class="text-xs text-foreground-muted mt-1.5"
@@ -495,7 +445,7 @@
           :disabled="!form.function_name || !form.cron"
           @click="saveSchedule"
         >
-          {{ editingJob ? 'Update' : 'Create' }} Schedule
+          {{ editingJob ? 'Update' : 'Create' }} schedule
         </Button>
       </template>
     </Modal>
@@ -504,9 +454,10 @@
 
 <script setup>
 import { EMPTY } from '@/utils/format'
-import { ref, onMounted } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { PlusCircle, Trash2, Clock, Edit, Play, Pause, CheckCircle2 } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import IconButton from '@/components/common/IconButton.vue'
 import Modal from '@/components/common/Modal.vue'
 import LoadError from '@/components/common/LoadError.vue'
@@ -544,6 +495,22 @@ const jobs = ref([])
 const loadError = ref('')
 const loaded = ref(false)
 const functions = ref([])
+const fnOptions = computed(() => [
+  { value: '', label: 'Select a function' },
+  ...functions.value.map((fn) => ({ value: fn.name, label: `${fn.name} (${runtimeLabel(fn.runtime)})` })),
+])
+const frequencyOptions = [
+  { value: 'minute', label: 'Every Minute' },
+  { value: 'hour', label: 'Hourly' },
+  { value: 'day', label: 'Daily' },
+  { value: 'week', label: 'Weekly' },
+  { value: 'month', label: 'Monthly' },
+]
+const dayOfWeekOptions = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+  .map((label, i) => ({ value: String(i), label }))
+const timezonePickerOptions = timezoneOptions.map((tz) => ({
+  value: tz, label: tz === detectedTZ ? `${tz}  (your browser)` : tz,
+}))
 const showCreateModal = ref(false)
 const editingJob = ref(null)
 const scheduleType = ref('simple')

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -2,7 +2,7 @@
   <div class="space-y-6">
     <div>
       <h1 class="text-xl font-semibold text-foreground-strong tracking-tight">
-        System Overview
+        System overview
       </h1>
       <p class="text-sm text-foreground-muted mt-1.5 max-w-prose leading-body">
         Live platform health and activity.
@@ -32,7 +32,7 @@
         <router-link
           v-if="sample.length"
           to="/invocations"
-          class="shrink-0 inline-flex items-center gap-1 text-xs text-foreground-muted hover:text-foreground-strong transition-colors rounded touch-expand-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+          class="shrink-0 inline-flex items-center gap-1 text-xs text-foreground-muted hover:text-foreground-strong transition-colors rounded-md touch-expand-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
         >
           {{ failures.length ? 'Inspect failures' : 'All invocations' }}
           <ArrowRight class="w-3.5 h-3.5" />

--- a/frontend/src/views/Deployments.vue
+++ b/frontend/src/views/Deployments.vue
@@ -20,7 +20,7 @@
           variant="secondary"
           @click="$router.push(`/functions/${fnName}`)"
         >
-          <UploadCloud class="w-4 h-4 mr-2" />
+          <UploadCloud class="w-4 h-4" />
           New version
         </Button>
         <Button
@@ -28,7 +28,7 @@
           @click="refresh"
         >
           <RefreshCw
-            class="w-4 h-4 mr-2"
+            class="w-4 h-4"
             :class="{ 'animate-spin': loading }"
           />
           Refresh
@@ -76,7 +76,7 @@
       {{ error }}
     </div>
 
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list. -->
       <ul class="sm:hidden divide-y divide-border">
         <li
@@ -93,7 +93,7 @@
                    wrap the whole row, because the row carries its own links. -->
               <button
                 type="button"
-                class="touch-expand-sm w-full text-left cursor-pointer rounded-sm active:bg-surface-hover/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm w-full text-left cursor-pointer rounded-md active:bg-surface-hover/50 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :aria-label="detailLabel(d)"
                 @click="open(d)"
               >
@@ -125,7 +125,7 @@
               <router-link
                 v-if="canCompare(d)"
                 :to="{ name: 'function-diff', params: { name: fnName }, query: { from: d.id, to: activeDeploymentId } }"
-                class="text-foreground-muted hover:text-foreground-strong text-xs flex items-center gap-1 px-2 py-1 rounded-sm touch-expand-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="text-foreground-muted hover:text-foreground-strong text-xs inline-flex items-center gap-1 h-7 px-2.5 rounded-md touch-expand-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :title="`Compare v${d.version} with the live version`"
               >
                 <GitCompare class="w-3 h-3" /> Compare
@@ -185,7 +185,7 @@
                      bare, so the desktop cell looks exactly as it did. -->
                 <button
                   type="button"
-                  class="touch-expand-xs text-foreground-strong text-left rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  class="touch-expand-xs text-foreground-strong text-left rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   :class="isActive(d) ? 'font-semibold' : 'text-foreground-muted'"
                   :aria-label="detailLabel(d)"
                   @click.stop="open(d)"
@@ -233,7 +233,7 @@
                 <router-link
                   v-if="canCompare(d)"
                   :to="{ name: 'function-diff', params: { name: fnName }, query: { from: d.id, to: activeDeploymentId } }"
-                  class="touch-expand-xs text-foreground-muted hover:text-foreground-strong flex items-center gap-1 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  class="touch-expand-xs text-foreground-muted hover:text-foreground-strong inline-flex items-center gap-1 h-7 px-2.5 rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                   :title="`Compare v${d.version} with the live version, v${liveVersion}`"
                 >
                   <GitCompare class="w-3 h-3" /> Compare with live

--- a/frontend/src/views/Docs.vue
+++ b/frontend/src/views/Docs.vue
@@ -29,6 +29,7 @@
                 v-else
                 class="w-4 h-4"
               />
+              <span class="docs-hero-copy-label">{{ docsCopied ? 'Copied' : 'Copy as Markdown' }}</span>
             </button>
           </div>
         </div>
@@ -2272,7 +2273,7 @@ const CodeBlock = defineComponent({
       h('div', { class: 'doc-codeblock' }, [
         h('div', { class: 'doc-codeblock-bar' }, [
           h('span', { class: 'doc-codeblock-lang' }, props.lang || ''),
-          h('button', { class: 'doc-codeblock-copy', onClick: onCopy, title: 'Copy code' }, [
+          h('button', { class: 'doc-codeblock-copy touch-expand-xs', onClick: onCopy, title: 'Copy code' }, [
             copied.value ? h(Check, { class: 'w-3 h-3' }) : h(Copy, { class: 'w-3 h-3' }),
             copied.value ? 'Copied' : 'Copy',
           ]),
@@ -2428,21 +2429,36 @@ const Callout = defineComponent({
   align-items: flex-start;
   flex-shrink: 0;
 }
-/* Icon-only Copy button. Sits in the top-right corner of the hero
-   row — quiet by default, primary tint on hover, green check on
-   success. Same 1.2s flip pattern as CodeBlock copy. */
+/* Icon-only Copy button beside the title. Below sm it wraps onto its own line,
+   where a lone glyph says nothing, so it takes its label there. */
 .docs-hero-copy-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 30.4px;
   height: 30.4px;
-  border-radius: 0.45rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
   cursor: pointer;
   transition: color 120ms, border-color 120ms, background-color 120ms;
+}
+.docs-hero-copy-label {
+  display: none;
+}
+@media (max-width: 639px) {
+  .docs-hero-copy-icon {
+    width: auto;
+    flex-shrink: 0;
+    gap: 0.5rem;
+    padding-inline: 0.75rem;
+    white-space: nowrap;
+  }
+  .docs-hero-copy-label {
+    display: inline;
+    font-size: 0.8125rem;
+  }
 }
 .docs-hero-copy-icon:hover {
   color: var(--color-foreground);
@@ -2486,7 +2502,7 @@ const Callout = defineComponent({
   align-items: center;
   gap: 0.4rem;
   padding: 0.32rem 0.6rem;
-  border-radius: 0.4rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
@@ -2867,7 +2883,7 @@ const Callout = defineComponent({
   margin-top: 0.5rem;
   padding: 0.45rem 0.85rem;
   border: 1px solid var(--color-border);
-  border-radius: 0.45rem;
+  border-radius: var(--radius-md);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
   font-family: var(--font-sans);
@@ -3152,7 +3168,7 @@ const Callout = defineComponent({
   color: var(--color-foreground);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
-  border-radius: 0.4rem;
+  border-radius: var(--radius-md);
   cursor: pointer;
   transition: background 120ms, border-color 120ms;
 }
@@ -3190,6 +3206,7 @@ const Callout = defineComponent({
   color: var(--color-foreground);
   user-select: none;
   transition: background 120ms;
+  border-radius: var(--radius-md);
 }
 .doc-details-summary::-webkit-details-marker {
   display: none;
@@ -3239,7 +3256,7 @@ const Callout = defineComponent({
   padding: 0.3rem 0.6rem;
   background: var(--color-background);
   border: 1px solid var(--color-border);
-  border-radius: 0.35rem;
+  border-radius: var(--radius-md);
   color: var(--color-foreground-muted);
   font-family: var(--font-sans);
   font-size: 11.5px;
@@ -3300,6 +3317,7 @@ const Callout = defineComponent({
   color: var(--color-foreground-muted);
   cursor: pointer;
   transition: color 120ms;
+  border-radius: var(--radius-md);
 }
 .doc-tabbed-tab:hover {
   color: var(--color-foreground);
@@ -3392,7 +3410,7 @@ const Callout = defineComponent({
   align-items: center;
   gap: 0.4rem;
   padding: 0.4rem 0.75rem;
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
@@ -3416,17 +3434,24 @@ const Callout = defineComponent({
    vertical padding so the taller copy button costs a few pixels per
    snippet rather than a full row. */
 @media (pointer: coarse) {
-  .docs-hero-copy-icon {
-    width: 44px;
-    height: 44px;
-  }
+  /* These carry a hard fine-pointer height, which min-height cannot lift, and
+     the fine-pointer rung also overwrote the floor they used to declare. */
+  .docs-hero-copy-icon,
   .docs-hero-toc-link,
-  .doc-token-btn,
   .doc-prompt-expand-btn,
-  .doc-ai-copy-btn,
+  .doc-token-btn,
   .doc-details-summary,
-  .doc-codeblock-copy {
+  .doc-tabbed-tab,
+  .doc-ai-copy-btn {
+    height: auto;
     min-height: 44px;
+  }
+
+  /* min-width, not width: below sm this button takes its label and has to be
+     able to grow past the floor. */
+  .docs-hero-copy-icon {
+    min-width: 44px;
+    height: 44px;
   }
   .doc-tabbed-tab {
     display: inline-flex;

--- a/frontend/src/views/Editor.vue
+++ b/frontend/src/views/Editor.vue
@@ -197,7 +197,7 @@
           @click="deployFunction"
         >
           <UploadCloud class="w-4 h-4" />
-          {{ isEditing ? 'Deploy New Version' : 'Deploy' }}
+          {{ isEditing ? 'Deploy new version' : 'Deploy' }}
         </Button>
       </div><!-- /mobile-row wrapper for dropdowns + actions -->
     </div>
@@ -211,7 +211,7 @@
       <span class="text-foreground-muted shrink-0 uppercase tracking-wider text-[10px]">Invoke URL</span>
       <code class="font-mono text-foreground-strong truncate flex-1 min-w-0">{{ invokeUrl }}</code>
       <button
-        class="px-2 py-1 rounded text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover transition-colors flex items-center gap-1 shrink-0 touch-expand-sm"
+        class="touch-expand-xs inline-flex items-center h-7 px-2.5 rounded-md text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover transition-colors flex items-center gap-1 shrink-0 touch-expand-sm"
         @click="copyInvokeUrl"
       >
         <Check
@@ -227,7 +227,7 @@
       <router-link
         v-if="isEditing && form.name"
         :to="`/functions/${form.name}/deployments`"
-        class="text-foreground-muted hover:text-foreground-strong transition-colors px-2 flex items-center touch-expand-sm"
+        class="text-foreground-muted hover:text-foreground-strong transition-colors inline-flex h-7 items-center rounded-md px-2.5 touch-expand-sm"
       >
         Deployments →
       </router-link>
@@ -326,7 +326,7 @@
             Run
           </button>
           <button
-            class="p-1.5 rounded text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover transition-colors touch-expand-iconbtn inline-flex items-center justify-center"
+            class="p-1.5 rounded-md text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover transition-colors touch-expand-iconbtn inline-flex items-center justify-center"
             :title="terminalOpen ? 'Collapse' : 'Expand'"
             :aria-label="terminalOpen ? 'Collapse terminal' : 'Expand terminal'"
             @click="terminalOpen = !terminalOpen"
@@ -402,20 +402,14 @@
                 for="test-method"
                 class="sr-only"
               >Request method</label>
-              <select
-                id="test-method"
+              <FilterSelect
                 v-model="testMethod"
+                :options="methodOptions"
                 :disabled="!canTest"
-                class="text-[11px] font-mono bg-background border border-border rounded px-1.5 py-0.5 text-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
-              >
-                <option
-                  v-for="m in methods"
-                  :key="m"
-                  :value="m"
-                >
-                  {{ m }}
-                </option>
-              </select>
+                label="Method"
+                trigger-id="test-method"
+                bare
+              />
               <label
                 for="test-path"
                 class="sr-only"
@@ -707,7 +701,7 @@
             v-model="form.description"
             rows="2"
             placeholder="One-line summary of what this function does. Surfaces in MCP tool catalogs and the agent channel picker."
-            class="w-full bg-surface-hover border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring resize-y"
+            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring resize-y"
           />
         </div>
         <div>
@@ -750,29 +744,14 @@
             for="fn-template"
             class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
           >Template</label>
-          <select
-            id="fn-template"
+          <FilterSelect
             v-model="templateId"
-            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-            @change="applyTemplate"
-          >
-            <option value="">
-              Custom (blank)
-            </option>
-            <optgroup
-              v-for="cat in groupedTemplates"
-              :key="cat.label"
-              :label="cat.label"
-            >
-              <option
-                v-for="tpl in cat.items"
-                :key="tpl.id"
-                :value="tpl.id"
-              >
-                {{ tpl.label }}{{ tpl.cron ? ' · scheduled' : '' }}: {{ tpl.description }}
-              </option>
-            </optgroup>
-          </select>
+            :options="templateOptions"
+            label="Custom (blank)"
+            trigger-id="fn-template"
+            wide
+            @update:model-value="applyTemplate"
+          />
           <p
             v-if="selectedTemplateDescription"
             class="text-[11px] text-foreground-muted mt-1.5"
@@ -813,19 +792,14 @@
                 for="fn-concurrency-policy"
                 class="text-xs font-medium text-foreground-muted uppercase tracking-wide block mb-1.5"
               >When at cap</label>
-              <select
-                id="fn-concurrency-policy"
+              <FilterSelect
                 v-model="form.concurrency_policy"
+                :options="concurrencyPolicyOptions"
                 :disabled="!form.max_concurrency"
-                class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring disabled:opacity-50"
-              >
-                <option value="queue">
-                  Queue requests
-                </option>
-                <option value="reject">
-                  Reject (429)
-                </option>
-              </select>
+                label="When at cap"
+                trigger-id="fn-concurrency-policy"
+                wide
+              />
             </div>
           </div>
           <p class="text-[11px] text-foreground-muted leading-snug">
@@ -861,21 +835,13 @@
           >
             <Lock class="w-3.5 h-3.5" /> Invoke gate
           </label>
-          <select
-            id="fn-auth-mode"
+          <FilterSelect
             v-model="form.auth_mode"
-            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-          >
-            <option value="none">
-              Public, anyone can invoke
-            </option>
-            <option value="platform_key">
-              Require Orva API key (server-to-server)
-            </option>
-            <option value="signed">
-              Require HMAC signature (X-Orva-Signature)
-            </option>
-          </select>
+            :options="authModeOptions"
+            label="Invoke gate"
+            trigger-id="fn-auth-mode"
+            wide
+          />
           <p class="text-[11px] text-foreground-muted leading-snug">
             Public is the default, matches Cloudflare Workers and Vercel
             Functions. For end-user auth (JWT, session cookies), keep this on
@@ -1078,7 +1044,7 @@
         <textarea
           v-model="dependencyText"
           aria-label="Dependencies, one package per line"
-          class="w-full bg-surface-hover border border-border rounded-md text-xs font-mono p-3 text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring resize-none min-h-[200px]"
+          class="w-full bg-background border border-border rounded-md text-xs font-mono p-3 text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring resize-none min-h-[200px]"
           placeholder="One package per line. e.g. requests==2.31.0"
         />
       </div>
@@ -1215,7 +1181,7 @@
             </router-link>
             <button
               :disabled="rollingBack"
-              class="text-foreground-muted hover:text-foreground-strong disabled:opacity-50 flex items-center gap-1"
+              class="touch-expand-xs inline-flex h-7 items-center gap-1 rounded-md px-2.5 text-foreground-muted hover:bg-surface-hover hover:text-foreground-strong disabled:opacity-50"
               @click="rollbackToVersion(v)"
             >
               <RotateCcw class="w-3 h-3" /> Rollback
@@ -1244,7 +1210,7 @@
           Export a single <code class="font-mono text-foreground-strong">handler(event)</code> that returns an
           HTTP-shaped object. Orva injects env vars and secrets at spawn time.
         </p>
-        <pre class="bg-surface border border-border rounded p-3 font-mono text-[12px] text-foreground-strong overflow-x-auto whitespace-pre">{{ handlerHint }}</pre>
+        <pre class="bg-surface border border-border rounded p-3 font-mono text-[12px] text-foreground-strong overflow-x-auto scrollable whitespace-pre">{{ handlerHint }}</pre>
         <ul class="space-y-1 pl-4 list-disc marker:text-foreground-muted">
           <li><span class="text-foreground-strong font-mono">event.body</span> is the raw request body (string or parsed JSON).</li>
           <li>Return <span class="text-foreground-strong font-mono">{ statusCode, headers, body }</span>.</li>
@@ -1359,7 +1325,7 @@
       </div>
       <template #footer>
         <Button
-          variant="secondary"
+          variant="ghost"
           @click="modals.firstDeploy = false"
         >
           Cancel
@@ -1381,6 +1347,7 @@ import { ref, computed, defineAsyncComponent, h, nextTick, onMounted, onBeforeUn
 import { useRoute, useRouter } from 'vue-router'
 import { FileCode, UploadCloud, Play, Layers, KeyRound, ShieldCheck, RotateCcw, Copy, Check, BookOpen, ChevronDown, Settings2, Variable, Package, X, Trash2, Terminal, Globe, Lock, Shuffle, Database, Sparkles, Webhook, Plug, GitCompare } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import Input from '@/components/common/Input.vue'
 import Modal from '@/components/common/Modal.vue'
 import PythonIcon from '@/components/icons/brand/PythonIcon.vue'
@@ -1568,6 +1535,16 @@ const testPath = ref('/')
 const testHeaders = ref([])
 const headersOpen = ref(false)
 const methods = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE']
+const methodOptions = methods.map((m) => ({ value: m, label: m }))
+const concurrencyPolicyOptions = [
+  { value: 'queue', label: 'Queue requests' },
+  { value: 'reject', label: 'Reject (429)' },
+]
+const authModeOptions = [
+  { value: 'none', label: 'Public, anyone can invoke' },
+  { value: 'platform_key', label: 'Require Orva API key (server-to-server)' },
+  { value: 'signed', label: 'Require HMAC signature (X-Orva-Signature)' },
+]
 const fixtures = ref([])
 const savedPopoverOpen = ref(false)
 const savedPopoverRef = ref(null)
@@ -1820,7 +1797,7 @@ const applyTemplate = () => {
   }
 }
 
-// Templates grouped by category for the picker's <optgroup>s. Categories
+// Templates grouped by category for the picker. Categories
 // render in `categoryOrder`; an entry with no category falls into "Other".
 const groupedTemplates = computed(() => {
   const list = templates[form.value.runtime] || []
@@ -1838,6 +1815,17 @@ const groupedTemplates = computed(() => {
   }
   return ordered
 })
+
+const templateOptions = computed(() => [
+  { value: '', label: 'Custom (blank)' },
+  ...groupedTemplates.value.flatMap((cat) => [
+    { header: true, label: cat.label },
+    ...cat.items.map((tpl) => ({
+      value: tpl.id,
+      label: `${tpl.label}${tpl.cron ? ' · scheduled' : ''}: ${tpl.description}`,
+    })),
+  ]),
+])
 
 const selectedTemplateDescription = computed(() => {
   const list = templates[form.value.runtime] || []
@@ -2880,7 +2868,7 @@ const resetForm = async () => {
 
    This used to be a ::before overlay inset -8px vertically. That is the
    exact pattern style.css removed: the toolbar is flex-wrap, so when
-   "Deploy New Version" pushes the row past a phone's width the buttons
+   "Deploy new version" pushes the row past a phone's width the buttons
    wrap onto two rows separated by gap-2 (7.6 px) and each row-2 overlay
    covered the row-1 buttons above it — winning the hit test on paint
    order and swallowing taps meant for Config. Grow the box, never the
@@ -2889,8 +2877,8 @@ const resetForm = async () => {
   display: inline-flex;
   align-items: center;
   gap: 0.375rem;
-  padding: 0.375rem 0.625rem;
-  border-radius: 0.375rem;
+  padding: 0 0.625rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background-color: var(--color-surface-hover);
   color: var(--color-foreground-muted);
@@ -2898,6 +2886,7 @@ const resetForm = async () => {
   font-weight: 500;
   white-space: nowrap;
   transition: color 150ms ease, background-color 150ms ease, border-color 150ms ease;
+  height: 30.4px;
 }
 .panel-btn:hover {
   color: var(--color-foreground);
@@ -2929,6 +2918,7 @@ const resetForm = async () => {
   text-align: left;
   cursor: pointer;
   transition: background-color 120ms ease;
+  border-radius: var(--radius-md);
 }
 .menu-item:hover,
 .menu-item:focus-visible {
@@ -2946,8 +2936,8 @@ const resetForm = async () => {
   display: inline-flex;
   align-items: center;
   gap: 0.3rem;
-  padding: 0.2rem 0.55rem;
-  border-radius: 0.3rem;
+  padding: 0 0.55rem;
+  border-radius: var(--radius-md);
   border: 1px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
   background: color-mix(in srgb, var(--color-primary) 18%, transparent);
   color: var(--color-foreground);
@@ -2955,6 +2945,7 @@ const resetForm = async () => {
   font-weight: 500;
   cursor: pointer;
   transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+  height: 26.6px;
 }
 .run-btn:hover:not(:disabled) {
   background: color-mix(in srgb, var(--color-primary) 32%, transparent);
@@ -2974,17 +2965,37 @@ const resetForm = async () => {
    cannot lift. Desktop (fine pointers) is untouched. */
 @media (pointer: coarse) {
   .panel-btn {
-    min-height: 44px;
-  }
-  .run-btn {
-    min-height: 44px;
-  }
-  .terminal-bar {
     height: auto;
     min-height: 44px;
   }
+
+  /* Run sat at 44px inside a 44px bar: a bordered control exactly as tall as
+     the strip containing it, touching both edges, which is what made it read
+     as a slab rather than a button. It takes the sm rung (36px) and buys the
+     rest of its target the same bounded way the shared helpers do. */
+  .run-btn {
+    height: auto;
+    min-height: 36px;
+    position: relative;
+  }
+  .run-btn::after {
+    content: '';
+    position: absolute;
+    top: -4px;
+    bottom: -4px;
+    left: 0;
+    right: 0;
+  }
+
+  /* The bar has to be taller than the control it holds, or there is no bar
+     left to see. Tabs stay full-height because their underline is the
+     selected-state indicator and it belongs on the bar's own bottom edge. */
+  .terminal-bar {
+    height: auto;
+    min-height: 48px;
+  }
   .terminal-tab {
-    height: 44px;
+    height: 48px;
   }
   /* The method select inside this bar inherits the global 44 px form-control
      floor, which overflowed a hard h-7 (26.6 px) row and painted over the

--- a/frontend/src/views/Firewall.vue
+++ b/frontend/src/views/Firewall.vue
@@ -22,14 +22,16 @@
           -->
           <Button
             variant="secondary"
-            size="sm"
-            :loading="resolving"
+            size="md"
             @click="forceResolve"
           >
-            <RefreshCw class="w-4 h-4" /> Refresh policy
+            <RefreshCw
+              :class="{ 'animate-spin': resolving }"
+              aria-hidden="true"
+            /> Refresh policy
           </Button>
           <Button
-            size="sm"
+            size="md"
             @click="showCreate = true"
           >
             <Plus class="w-4 h-4" /> Add block
@@ -76,7 +78,11 @@
 
       <!-- Detailed policy state stays available without competing with status. -->
       <details class="group">
-        <summary class="touch-expand-sm inline-flex items-center cursor-pointer text-xs text-foreground-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary">
+        <summary class="touch-expand-sm inline-flex items-center gap-1.5 cursor-pointer list-none text-xs text-foreground-muted hover:text-foreground-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary [&::-webkit-details-marker]:hidden">
+          <ChevronRight
+            class="w-3.5 h-3.5 shrink-0 transition-transform group-open:rotate-90"
+            aria-hidden="true"
+          />
           Policy details
         </summary>
         <div class="policy-meta mt-2">
@@ -263,7 +269,7 @@
           </span>
           <button
             v-if="dns.servers.length || dns.search || dns.records.length"
-            class="inline-flex items-center text-xs text-foreground-muted hover:text-foreground-strong px-2 py-1 transition-colors touch-expand-sm"
+            class="inline-flex items-center h-8 px-3 text-xs text-foreground-muted hover:text-foreground-strong rounded-md transition-colors touch-expand-sm"
             @click="resetDNS"
           >
             Reset
@@ -428,7 +434,7 @@
       </div>
       <template #footer>
         <Button
-          variant="secondary"
+          variant="ghost"
           @click="showCreate = false"
         >
           Cancel
@@ -450,7 +456,7 @@
 import { computed, h, onMounted, onActivated, onDeactivated, ref, defineComponent } from 'vue'
 import {
   Plus, RefreshCw, ShieldAlert, ShieldOff, ShieldCheck,
-  AlertTriangle, Globe, Globe2, Asterisk, Hash, Trash2,
+  AlertTriangle, Globe, Globe2, Asterisk, Hash, Trash2, ChevronRight,
 } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
 import Input from '@/components/common/Input.vue'
@@ -1119,14 +1125,15 @@ const RuleCard = defineComponent({
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
-  padding: 0.3rem 0.7rem;
-  border-radius: 999px;
+  padding: 0 0.7rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
   font-size: 12px;
   cursor: pointer;
   transition: color 150ms ease, border-color 150ms ease, background-color 150ms ease;
+  height: 26.6px;
 }
 .rule-filter:hover {
   color: var(--color-foreground-strong);
@@ -1375,6 +1382,11 @@ const RuleCard = defineComponent({
 /* On/off is the primary control on this page and it painted a 36x20 target.
    Only the hit box grows; the track keeps its mouse-density proportions. */
 @media (pointer: coarse) {
+  /* The tier owns the touch height; the fine-pointer `height` must yield. */
+  .rule-filter {
+    height: auto;
+  }
+
   .rule-toggle {
     min-width: 44px;
     min-height: 44px;
@@ -1579,21 +1591,23 @@ const RuleCard = defineComponent({
    honest at any container size, and the row wraps when the viewport
    shrinks. */
 .dns-input {
+    height: auto;
   background: var(--color-background);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
-  padding: 0.35rem 0.65rem;
+  border-radius: var(--radius-md);
+  padding: 0 0.65rem;
   font-size: 12px;
   font-family: var(--font-mono);
   color: var(--color-foreground);
   flex: 0 0 auto;
   width: 18ch;        /* default: IP-sized */
+  height: 30.4px;
 }
 .dns-input.host {
   width: 26ch;        /* hostname slot — slightly wider */
 }
 .dns-input.narrow {
-  width: 14ch;        /* search domain etc. */
+  width: 17ch;        /* fits "search domain" -- 14ch clipped its own placeholder */
 }
 /* The ch-based widths and 12px type above are a mouse-density choice, and on a
    coarse pointer they cost twice: 12px re-triggers iOS focus zoom (the global

--- a/frontend/src/views/FunctionDiff.vue
+++ b/frontend/src/views/FunctionDiff.vue
@@ -31,7 +31,7 @@
           variant="secondary"
           @click="$router.push(`/functions/${fnName}/deployments`)"
         >
-          <List class="w-4 h-4 mr-2" />
+          <List class="w-4 h-4" />
           All deployments
         </Button>
       </div>
@@ -52,27 +52,14 @@
             From
             <span class="ml-1 text-foreground-muted normal-case font-medium tracking-normal">(older)</span>
           </label>
-          <select
-            id="diff-from"
-            :value="fromId"
-            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-            @change="updateRange({ from: $event.target.value })"
-          >
-            <option
-              value=""
-              disabled
-            >
-              Pick a version
-            </option>
-            <option
-              v-for="v in versionOptions"
-              :key="v.id"
-              :value="v.id"
-              :disabled="v.id === toId"
-            >
-              {{ versionLabel(v) }}
-            </option>
-          </select>
+          <FilterSelect
+            :model-value="fromId"
+            :options="fromOptions"
+            label="Pick a version"
+            trigger-id="diff-from"
+            wide
+            @update:model-value="updateRange({ from: $event })"
+          />
         </div>
         <button
           :disabled="!fromId || !toId"
@@ -91,27 +78,14 @@
             To
             <span class="ml-1 text-foreground-muted normal-case font-medium tracking-normal">(newer)</span>
           </label>
-          <select
-            id="diff-to"
-            :value="toId"
-            class="w-full bg-background border border-border rounded-md px-3 py-2 text-sm font-mono text-foreground focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
-            @change="updateRange({ to: $event.target.value })"
-          >
-            <option
-              value=""
-              disabled
-            >
-              Pick a version
-            </option>
-            <option
-              v-for="v in versionOptions"
-              :key="v.id"
-              :value="v.id"
-              :disabled="v.id === fromId"
-            >
-              {{ versionLabel(v) }}
-            </option>
-          </select>
+          <FilterSelect
+            :model-value="toId"
+            :options="toOptions"
+            label="Pick a version"
+            trigger-id="diff-to"
+            wide
+            @update:model-value="updateRange({ to: $event })"
+          />
         </div>
       </div>
 
@@ -388,6 +362,7 @@ import Button from '@/components/common/Button.vue'
 import { ArrowLeftRight, Copy, Settings2, ChevronDown, FileCode, Package, List, RotateCcw, Zap } from '@lucide/vue'
 import { compareDeployments, listDeployments, listFunctions, getDeployment, rollbackFunction } from '@/api/endpoints'
 import { describeSnapshotDiff } from '@/utils/rollbackDiff'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import { copyText } from '@/utils/clipboard'
 import { useConfirmStore } from '@/stores/confirm'
 
@@ -744,6 +719,14 @@ const compactWhen = (iso) => {
   return `${date} ${time}`
 }
 
+const fromOptions = computed(() => [
+  { value: '', label: 'Pick a version', disabled: true },
+  ...versionOptions.value.map((v) => ({ value: v.id, label: versionLabel(v), disabled: v.id === toId.value })),
+])
+const toOptions = computed(() => [
+  { value: '', label: 'Pick a version', disabled: true },
+  ...versionOptions.value.map((v) => ({ value: v.id, label: versionLabel(v), disabled: v.id === fromId.value })),
+])
 const versionLabel = (v) =>
   `v${v.version} · ${v.shortHash} · ${compactWhen(v.submittedAt)}${v.isActive ? ' · active' : ''}`
 

--- a/frontend/src/views/FunctionsList.vue
+++ b/frontend/src/views/FunctionsList.vue
@@ -20,7 +20,7 @@
       </div>
       <Button @click="router.push('/functions/new')">
         <Plus class="w-4 h-4" />
-        New Function
+        New function
       </Button>
     </div>
 
@@ -45,7 +45,7 @@
           <input
             v-model="search"
             placeholder="Search by name, runtime, or function id…"
-            class="w-full bg-background border border-border rounded-md pl-8 pr-3 py-1.5 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
+            class="h-7 w-full bg-background border border-border rounded-md pl-8 pr-3 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
           >
         </div>
         <span class="text-[11px] text-foreground-muted shrink-0 tabular-nums">
@@ -53,7 +53,7 @@
         </span>
       </div>
 
-      <div class="bg-background border border-border rounded-lg overflow-x-auto">
+      <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
         <!--
         Mobile (<sm) stacked-row list. Each card carries: name + badges,
         description (clamped), a runtime / resources / function-id
@@ -338,7 +338,7 @@
           class="flex justify-center border-t border-border py-3 bg-surface/30"
         >
           <button
-            class="touch-expand-xs text-xs text-foreground-muted hover:text-foreground-strong transition-colors flex items-center gap-1.5"
+            class="touch-expand-sm inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-xs text-foreground-muted hover:bg-surface-hover hover:text-foreground-strong transition-colors"
             :disabled="loading"
             @click="loadMore"
           >

--- a/frontend/src/views/InboundWebhooks.vue
+++ b/frontend/src/views/InboundWebhooks.vue
@@ -26,7 +26,7 @@
         </span>
         <Button
           variant="secondary"
-          size="sm"
+          size="md"
           @click="refresh"
         >
           <RefreshCw
@@ -36,7 +36,7 @@
           Refresh
         </Button>
         <Button
-          size="sm"
+          size="md"
           @click="openCreate()"
         >
           <Plus class="w-3.5 h-3.5" />
@@ -90,7 +90,7 @@
     </div>
 
     <!-- Table -->
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list. -->
       <ul class="sm:hidden divide-y divide-border">
         <li
@@ -297,27 +297,15 @@
             for="inbound-format"
             class="text-xs uppercase tracking-wider text-foreground-muted"
           >Signature format</label>
-          <select
-            id="inbound-format"
-            v-model="create.format"
-            class="mt-2 w-full bg-surface border border-border rounded px-3 py-2 text-sm text-foreground-strong focus:outline-none focus:border-focus-ring"
-          >
-            <option value="hmac_sha256_hex">
-              hmac_sha256_hex (default)
-            </option>
-            <option value="hmac_sha256_base64">
-              hmac_sha256_base64
-            </option>
-            <option value="github">
-              github (X-Hub-Signature-256)
-            </option>
-            <option value="stripe">
-              stripe (Stripe-Signature)
-            </option>
-            <option value="slack">
-              slack (X-Slack-Signature)
-            </option>
-          </select>
+          <div class="mt-2">
+            <FilterSelect
+              v-model="create.format"
+              :options="formatOptions"
+              label="Signature format"
+              trigger-id="inbound-format"
+              wide
+            />
+          </div>
           <p class="text-[11px] text-foreground-muted mt-2">
             Pick the format your upstream service produces. The header name is
             stamped automatically; you can override on the row after creation.
@@ -425,6 +413,7 @@ import { ref, reactive, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import { Plus, Trash2, Send, RefreshCw, Pause, Play } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import IconButton from '@/components/common/IconButton.vue'
 import Drawer from '@/components/common/Drawer.vue'
 import { listInboundWebhooks, createInboundWebhook, deleteInboundWebhook, updateInboundWebhook, signInboundWebhook } from '@/api/endpoints'
@@ -443,6 +432,13 @@ const testing = ref(false)
 const lastCreated = ref(null)
 const origin = computed(() => window.location.origin)
 
+const formatOptions = [
+  { value: 'hmac_sha256_hex', label: 'hmac_sha256_hex (default)' },
+  { value: 'hmac_sha256_base64', label: 'hmac_sha256_base64' },
+  { value: 'github', label: 'github (X-Hub-Signature-256)' },
+  { value: 'stripe', label: 'stripe (Stripe-Signature)' },
+  { value: 'slack', label: 'slack (X-Slack-Signature)' },
+]
 const create = reactive({
   open: false,
   name: '',

--- a/frontend/src/views/InvocationsLog.vue
+++ b/frontend/src/views/InvocationsLog.vue
@@ -14,7 +14,7 @@
         @click="refresh"
       >
         <RefreshCw
-          class="w-4 h-4 mr-2"
+          class="w-4 h-4"
           :class="{ 'animate-spin': loading }"
         />
         Refresh
@@ -26,47 +26,40 @@
          filters appear inline as compact chips. Active filters render
          as removable pills next to the chips. -->
     <div class="flex items-center gap-2 flex-wrap">
-      <div class="relative flex-1 min-w-0 sm:min-w-[280px] max-w-full sm:max-w-[440px]">
+      <div class="relative basis-full sm:basis-auto sm:flex-1 min-w-0 sm:min-w-[280px] max-w-full sm:max-w-[440px]">
         <Search class="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-foreground-muted pointer-events-none" />
         <input
           v-model="filters.q"
           placeholder="Search errors, container ids…"
           aria-label="Search invocations by error or container id"
-          class="w-full bg-background border border-border rounded-md pl-8 pr-3 py-1.5 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
+          class="h-7 w-full bg-background border border-border rounded-md pl-8 pr-3 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
           @input="onSearchInput"
         >
       </div>
 
-      <FilterChip
+      <FilterSelect
         :options="statusOptions"
         :model-value="filters.status"
         label="Status"
         @update:model-value="filters.status = $event; onFilterChange()"
       />
-      <FilterChip
+      <FilterSelect
         :options="rangeOptions"
         :model-value="filters.range"
         label="Range"
         @update:model-value="filters.range = $event; onFilterChange()"
       />
 
-      <select
-        v-model="filters.fnId"
-        aria-label="Filter by function"
-        class="h-7 bg-background border border-border rounded-md pl-2.5 pr-2 text-xs text-foreground-muted hover:text-foreground-strong focus:outline-none focus:border-focus-ring max-w-[180px]"
-        @change="onFilterChange"
-      >
-        <option value="">
-          All functions
-        </option>
-        <option
-          v-for="(name, id) in fnMap"
-          :key="id"
-          :value="id"
-        >
-          {{ name }}
-        </option>
-      </select>
+      <!-- Was a native <select>, which handed the phone its OS wheel while the
+           two chips beside it opened a custom panel: three controls that look
+           like one family and behaved like two. -->
+      <FilterSelect
+        :options="fnOptions"
+        :model-value="filters.fnId"
+        label="Function"
+        class="max-w-[180px]"
+        @update:model-value="filters.fnId = $event; onFilterChange()"
+      />
 
       <button
         v-if="hasActiveFilter"
@@ -137,7 +130,7 @@
                    the detail drawer out of reach of the keyboard entirely. -->
               <button
                 type="button"
-                class="touch-expand-sm w-full text-left cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm w-full text-left cursor-pointer rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :aria-label="detailLabel(log)"
                 @click="openDetail(log)"
               >
@@ -167,7 +160,7 @@
               <button
                 v-if="log.trace_id"
                 type="button"
-                class="touch-expand-xs mt-1 inline-flex items-center gap-1 py-1 text-[11px] text-foreground-muted hover:text-foreground-strong font-mono underline-offset-2 hover:underline rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-xs mt-1 inline-flex items-center gap-1 py-1 text-xs text-foreground-muted hover:text-foreground-strong font-mono underline-offset-2 hover:underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :title="log.trace_id"
                 @click="openTrace(log.trace_id)"
               >
@@ -260,7 +253,7 @@
                    bare, so the desktop cell looks exactly as it did. -->
               <button
                 type="button"
-                class="touch-expand-sm text-left rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm text-left rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :aria-label="detailLabel(log)"
                 @click.stop="openDetail(log)"
               >
@@ -271,7 +264,7 @@
               <button
                 v-if="log.trace_id"
                 type="button"
-                class="touch-expand-xs lg:hidden mt-1 flex items-center gap-1 text-xs text-foreground-muted hover:text-foreground-strong font-mono underline-offset-2 hover:underline rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-xs lg:hidden mt-1 flex items-center gap-1 text-xs text-foreground-muted hover:text-foreground-strong font-mono underline-offset-2 hover:underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :title="log.trace_id"
                 @click.stop="openTrace(log.trace_id)"
               >
@@ -282,7 +275,7 @@
             <td class="px-6 py-4 font-medium text-foreground-strong">
               <button
                 type="button"
-                class="touch-expand-sm text-left hover:underline rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm text-left hover:underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :aria-label="`Open function ${getFnName(log.function_id)}`"
                 @click.stop="router.push('/functions/' + getFnName(log.function_id))"
               >
@@ -344,7 +337,7 @@
         class="flex justify-center border-t border-border py-3 bg-surface/30"
       >
         <button
-          class="touch-expand-xs text-xs text-foreground-muted hover:text-foreground-strong transition-colors flex items-center gap-1.5"
+          class="touch-expand-sm inline-flex h-8 items-center gap-1.5 rounded-md px-3 text-xs text-foreground-muted hover:bg-surface-hover hover:text-foreground-strong transition-colors"
           :disabled="loading"
           @click="loadMore"
         >
@@ -618,7 +611,7 @@
             :title="replayTooltip"
             @click="replay"
           >
-            <Play class="w-4 h-4 mr-2" />
+            <Play class="w-4 h-4" />
             Replay
           </Button>
           <Button
@@ -629,7 +622,7 @@
             :title="suggestFixTooltip"
             @click="suggestFix"
           >
-            <Sparkles class="w-4 h-4 mr-2" />
+            <Sparkles class="w-4 h-4" />
             Suggest fix
           </Button>
           <span
@@ -646,9 +639,10 @@
 
 <script setup>
 import { EMPTY } from '@/utils/format'
-import { ref, computed, h, watch, defineComponent, onMounted, onUnmounted, onActivated, onDeactivated } from 'vue'
+import { ref, computed, h, watch, onMounted, onUnmounted, onActivated, onDeactivated } from 'vue'
 import { useRouter } from 'vue-router'
-import { RefreshCw, Search, ChevronDown, Check, Trash2, Play, RotateCcw, Sparkles, Network, CircleAlert } from '@lucide/vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
+import { RefreshCw, Search, Trash2, Play, RotateCcw, Sparkles, Network, CircleAlert } from '@lucide/vue'
 import Button from '@/components/common/Button.vue'
 import Drawer from '@/components/common/Drawer.vue'
 import StatusBadge from '@/components/common/StatusBadge.vue'
@@ -844,98 +838,11 @@ const Stat = {
 // a value is picked; once active, becomes a pill with the value + an x.
 // Click anywhere to open the menu, click an option to apply, click the x
 // to clear. Calmer than a row of always-visible buttons.
-const FilterChip = defineComponent({
-  name: 'FilterChip',
-  props: {
-    options:    { type: Array,   required: true },
-    modelValue: { type: String,  default: '' },
-    label:      { type: String,  required: true },
-  },
-  emits: ['update:modelValue'],
-  setup(p, { emit }) {
-    const open = ref(false)
-    const triggerRef = ref(null)
-    const active = computed(() => p.options.find((o) => o.value === p.modelValue && o.value !== ''))
-    const close = () => { open.value = false }
-    // Picking from the menu unmounts it, so hand focus back to the trigger
-    // rather than dropping it on <body>.
-    const choose = (v) => { emit('update:modelValue', v); close(); triggerRef.value?.focus() }
-    const clear = (e) => { e.stopPropagation(); emit('update:modelValue', '') }
-
-    // Close on outside click. Listener attached on first open + removed
-    // on close so we don't leak handlers.
-    const onDoc = (e) => {
-      if (!e.target.closest('.fc-root')) close()
-    }
-    return () =>
-      h('div', {
-        class: 'fc-root relative',
-        onMouseenter: () => { document.addEventListener('mousedown', onDoc) },
-        onMouseleave: () => { /* keep listener while open */ },
-        onKeydown: (e) => {
-          if (e.key === 'Escape' && open.value) { close(); triggerRef.value?.focus() }
-        },
-      }, [
-        // Visual rhythm matches Button variant=chip size=xs (h-7 px-2.5)
-        // so this stateful dropdown chip lines up with the flat toggle
-        // chips on Jobs.vue / Webhooks.vue. We can't reuse <Button> here
-        // because this trigger needs to host a child clear-x and a
-        // dropdown — different shape from a single-action chip. Button's
-        // coarse-pointer floor is not inherited with the classes, so
-        // touch-expand-md brings the 28 px target up to 44 px on touch
-        // hardware without moving the desktop height.
-        h('button', {
-          ref: triggerRef,
-          type: 'button',
-          'aria-expanded': open.value ? 'true' : 'false',
-          class: [
-            'inline-flex items-center gap-1.5 rounded-md border h-7 px-2.5 text-xs transition-colors touch-expand-md',
-            'focus:outline-none focus-visible:ring-2 focus-visible:ring-primary',
-            active.value
-              ? 'bg-primary text-primary-foreground border-primary'
-              : 'bg-surface text-foreground-muted border-border hover:text-foreground-strong hover:border-foreground-muted',
-          ],
-          onClick: () => { open.value = !open.value },
-        }, [
-          h('span', { class: 'text-[10px] uppercase tracking-wider' }, p.label + (active.value ? ':' : '')),
-          active.value ? h('span', null, active.value.label) : null,
-          // Mouse-only shortcut: it cannot be a button (this is already one)
-          // and it is not focusable, so it stays hidden from assistive tech.
-          // The keyboard path to the same result is the menu's own reset row.
-          active.value
-            ? h('span', {
-                class: 'opacity-70 hover:opacity-100 -mr-0.5',
-                onClick: clear,
-                title: 'Clear',
-                'aria-hidden': 'true',
-              }, '✕')
-            : h(ChevronDown, { class: 'w-3 h-3 opacity-60' }),
-        ]),
-        open.value
-          ? h('div', {
-              class: 'absolute z-30 mt-1 left-0 min-w-[140px] bg-background border border-border rounded-md shadow-xl py-1',
-            },
-              // The empty-value option ("All", "All time") stays in the menu:
-              // it is the only way to clear an active filter without a mouse.
-              p.options.map((o) =>
-                h('button', {
-                  key: o.value,
-                  type: 'button',
-                  class: [
-                    'w-full text-left px-2.5 py-1.5 text-xs flex items-center gap-2 transition-colors touch-expand-sm',
-                    'focus:outline-none focus-visible:bg-surface-hover focus-visible:text-foreground-strong',
-                    o.value === p.modelValue ? 'text-foreground-strong' : 'text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover',
-                  ],
-                  onClick: () => choose(o.value),
-                }, [
-                  h(Check, { class: ['w-3 h-3', o.value === p.modelValue ? 'opacity-100' : 'opacity-0'] }),
-                  o.label,
-                ]))
-          ) : null,
-      ])
-  },
-})
-
+// fnMap is { id: name } for the table's own lookups; the picker wants a list.
+const fnOptions = computed(() => [
+  { value: '', label: 'All functions' },
+  ...Object.entries(fnMap.value || {}).map(([id, name]) => ({ value: id, label: name })),
+])
 const formatTime = (ts) => (ts ? new Date(ts).toLocaleString() : EMPTY)
 
 // Accessible name for the row trigger: the visible text is just a timestamp,

--- a/frontend/src/views/Jobs.vue
+++ b/frontend/src/views/Jobs.vue
@@ -26,7 +26,7 @@
          rendering bug rather than a scroller. Below sm the actions take their
          own row and the strip gets the full width; sm+ is unchanged. -->
     <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-      <div class="flex items-center gap-2 sm:flex-wrap overflow-x-auto sm:overflow-visible scrollable snap-x min-w-0 flex-1">
+      <div class="flex items-center gap-2 sm:flex-wrap overflow-x-auto sm:overflow-visible scrollable swipe-x snap-x min-w-0 flex-1">
         <Button
           v-for="opt in statusOptions"
           :key="opt.value"
@@ -45,7 +45,6 @@
       </div>
       <div class="flex items-center gap-2 shrink-0">
         <Button
-          size="xs"
           @click="openEnqueue"
         >
           <Plus class="w-3 h-3" />
@@ -53,10 +52,9 @@
         </Button>
         <Button
           variant="secondary"
-          size="xs"
           @click="loadJobs"
         >
-          <RefreshCcw class="w-3 h-3" />
+          <RefreshCw />
           Refresh
         </Button>
       </div>
@@ -74,18 +72,14 @@
       <div class="p-5 space-y-5 text-sm">
         <div>
           <label class="text-xs uppercase tracking-wider text-foreground-muted">Function</label>
-          <select
-            v-model="enqueue.fnId"
-            class="mt-2 w-full bg-surface border border-border rounded px-3 py-2 text-sm text-foreground-strong focus:outline-none focus:border-focus-ring"
-          >
-            <option
-              v-for="f in functions"
-              :key="f.id"
-              :value="f.id"
-            >
-              {{ f.name }} ({{ runtimeLabel(f.runtime) }})
-            </option>
-          </select>
+          <div class="mt-2">
+            <FilterSelect
+              v-model="enqueue.fnId"
+              :options="fnOptions"
+              label="Function"
+              wide
+            />
+          </div>
         </div>
         <div>
           <label class="text-xs uppercase tracking-wider text-foreground-muted">Payload (JSON)</label>
@@ -154,7 +148,7 @@
     />
 
     <!-- Table. -->
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-card list. Surfaces every column the
            desktop table hides (status, attempts, scheduled, finished)
            so nothing is silently dropped on small screens. -->
@@ -349,13 +343,14 @@ defineOptions({ name: 'JobsView' })
 
 import { EMPTY } from '@/utils/format'
 import { ref, reactive, computed, onMounted, onUnmounted, onActivated, onDeactivated } from 'vue'
-import { Trash2, RotateCcw, RefreshCcw, Plus, CheckCircle2, XCircle, Clock, Circle } from '@lucide/vue'
+import { Trash2, RotateCcw, RefreshCw, Plus, CheckCircle2, XCircle, Clock, Circle } from '@lucide/vue'
 import { listJobs, retryJob, deleteJob, enqueueJob, listFunctions } from '@/api/endpoints'
 import { useConfirmStore } from '@/stores/confirm'
 import Button from '@/components/common/Button.vue'
 import IconButton from '@/components/common/IconButton.vue'
 import Drawer from '@/components/common/Drawer.vue'
 import LoadError from '@/components/common/LoadError.vue'
+import FilterSelect from '@/components/common/FilterSelect.vue'
 import { runtimeLabel } from '@/utils/runtime'
 
 const confirmStore = useConfirmStore()
@@ -364,6 +359,7 @@ const jobs = ref([])
 const loadError = ref('')
 const loaded = ref(false)
 const functions = ref([])
+const fnOptions = computed(() => functions.value.map((f) => ({ value: f.id, label: `${f.name} (${runtimeLabel(f.runtime)})` })))
 const statusFilter = ref('all')
 // countSource is always an unfiltered page: the pills count from it so they
 // stay meaningful while a filter narrows the table.

--- a/frontend/src/views/KVStore.vue
+++ b/frontend/src/views/KVStore.vue
@@ -4,7 +4,7 @@
     <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
       <div class="min-w-0">
         <h1 class="text-xl font-semibold text-foreground-strong tracking-tight">
-          KV Store
+          KV store
         </h1>
         <p class="text-sm text-foreground-muted mt-1.5 max-w-prose leading-body">
           JSON state for
@@ -24,7 +24,7 @@
         </span>
         <Button
           variant="secondary"
-          size="sm"
+          size="md"
           @click="refresh"
         >
           <RefreshCw
@@ -34,7 +34,7 @@
           Refresh
         </Button>
         <Button
-          size="sm"
+          size="md"
           @click="openSet()"
         >
           <Plus class="w-3.5 h-3.5" />
@@ -53,7 +53,7 @@
           v-model="prefix"
           aria-label="Search keys by prefix"
           placeholder="Search by key prefix… (e.g. user:)"
-          class="w-full bg-background border border-border rounded-md pl-8 pr-3 py-1.5 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
+          class="h-7 w-full bg-background border border-border rounded-md pl-8 pr-3 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus:ring-1 focus:ring-focus-ring focus:border-focus-ring"
           @input="onPrefixInput"
         >
       </div>
@@ -77,7 +77,7 @@
              clicks from neighbouring rows. -->
         <button
           type="button"
-          class="underline hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-sm"
+          class="touch-expand-sm inline-flex h-8 items-center rounded-md px-3 text-xs text-foreground-muted hover:bg-surface-hover hover:text-foreground-strong transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           :disabled="loading"
           @click="refresh({ append: true })"
         >
@@ -88,7 +88,7 @@
     </div>
 
     <!-- Table -->
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <!-- Mobile (<sm) stacked-row list. -->
       <ul class="sm:hidden divide-y divide-border">
         <li
@@ -103,7 +103,7 @@
                  list view where it was never applied. -->
             <button
               type="button"
-              class="min-w-0 flex-1 text-left rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+              class="min-w-0 flex-1 text-left rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
               :aria-label="inspectLabel(row)"
               @click="openInspect(row)"
             >
@@ -180,7 +180,7 @@
                    cell looks exactly as it did. -->
               <button
                 type="button"
-                class="touch-expand-sm block w-full truncate text-left font-mono text-xs text-foreground-strong rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm block w-full truncate text-left font-mono text-xs text-foreground-strong rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 :aria-label="inspectLabel(row)"
                 @click.stop="openInspect(row)"
               >

--- a/frontend/src/views/Login.vue
+++ b/frontend/src/views/Login.vue
@@ -17,7 +17,7 @@
       <!-- Login Card -->
       <div class="bg-surface border border-border rounded-lg shadow-lg p-8">
         <h2 class="text-xl font-semibold text-foreground mb-6">
-          Sign In
+          Sign in
         </h2>
 
         <!-- The focus ring is white, not primary: it marks where the cursor is
@@ -84,7 +84,7 @@
             :disabled="!form.username || !form.password || loading"
           >
             <LogIn class="w-4 h-4" />
-            Sign In
+            Sign in
           </Button>
         </form>
       </div>

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -15,7 +15,10 @@
          these values don't change while the binary is running). -->
     <details class="group border-b border-border pb-6">
       <summary class="touch-expand-sm flex cursor-pointer list-none items-center gap-2 text-sm font-semibold text-foreground-strong focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary [&::-webkit-details-marker]:hidden">
-        <Info class="w-4 h-4 text-foreground-muted" />
+        <ChevronRight
+          class="w-3.5 h-3.5 shrink-0 transition-transform group-open:rotate-90 text-foreground-muted"
+          aria-hidden="true"
+        />
         Build info
         <span class="ml-auto text-xs font-normal text-foreground-muted group-open:hidden">{{ buildInfo?.version || EMPTY }}</span>
       </summary>
@@ -51,7 +54,7 @@
                own content, so the glyph stays put. -->
           <button
             v-if="buildInfo?.image"
-            class="p-1 rounded hover:bg-surface text-foreground-muted hover:text-foreground-strong transition-colors shrink-0 touch-expand-iconbtn"
+            class="p-1 rounded-md hover:bg-surface text-foreground-muted hover:text-foreground-strong transition-colors shrink-0 touch-expand-iconbtn"
             title="Copy image reference"
             aria-label="Copy image reference"
             @click="copyImage"
@@ -96,7 +99,7 @@
             role="radio"
             :aria-checked="themePref === opt.value"
             :tabindex="themePref === opt.value ? 0 : -1"
-            class="touch-expand-sm inline-flex items-center gap-1.5 rounded px-3 h-8 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
+            class="touch-expand-sm inline-flex items-center gap-1.5 rounded-md px-3 h-8 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring"
             :class="themePref === opt.value
               ? 'bg-surface-hover text-foreground-strong'
               : 'text-foreground-muted hover:text-foreground hover:bg-surface-hover'"
@@ -305,7 +308,7 @@
               type="password"
               autocomplete="current-password"
               aria-describedby="pw-error"
-              class="bg-surface border border-border rounded-md px-3 py-2 text-sm text-foreground-strong placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-primary"
+              class="h-10 bg-surface border border-border rounded-md px-3 text-sm text-foreground-strong placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-primary"
               placeholder="••••••••"
             >
           </div>
@@ -320,7 +323,7 @@
               type="password"
               autocomplete="new-password"
               aria-describedby="pw-error"
-              class="bg-surface border border-border rounded-md px-3 py-2 text-sm text-foreground-strong placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-primary"
+              class="h-10 bg-surface border border-border rounded-md px-3 text-sm text-foreground-strong placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-primary"
               placeholder="••••••••"
             >
           </div>
@@ -335,7 +338,7 @@
               type="password"
               autocomplete="new-password"
               aria-describedby="pw-error"
-              class="bg-surface border border-border rounded-md px-3 py-2 text-sm text-foreground-strong placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-primary"
+              class="h-10 bg-surface border border-border rounded-md px-3 text-sm text-foreground-strong placeholder:text-foreground-muted focus:outline-none focus:ring-1 focus:ring-primary"
               placeholder="••••••••"
             >
           </div>
@@ -683,11 +686,11 @@ import {
   Monitor,
   Trash2,
   Ban,
-  Info,
   Copy,
   MessagesSquare,
   Sun,
   Moon,
+  ChevronRight,
 } from '@lucide/vue'
 import AISettingsPanel from '@/components/ai/AISettingsPanel.vue'
 import Button from '@/components/common/Button.vue'

--- a/frontend/src/views/Traces.vue
+++ b/frontend/src/views/Traces.vue
@@ -11,12 +11,11 @@
       </div>
       <Button
         variant="secondary"
-        size="sm"
-        :loading="loading"
+        size="md"
         @click="refresh"
       >
         <RefreshCw
-          class="w-3.5 h-3.5"
+          :class="{ 'animate-spin': loading }"
           aria-hidden="true"
         /> Refresh
       </Button>
@@ -33,7 +32,9 @@
         Trace filters
       </h2>
       <div class="flex flex-col sm:flex-row sm:items-center gap-2 sm:flex-wrap">
-        <label class="relative w-full sm:flex-1 sm:min-w-[260px] sm:max-w-[420px]">
+        <!-- block, not inline: an inline box would build the magnifier's
+             containing block from its own font metrics, not the field's. -->
+        <label class="relative block w-full sm:flex-1 sm:min-w-[260px] sm:max-w-[420px]">
           <span class="sr-only">Function ID or name</span>
           <Search
             class="w-3.5 h-3.5 absolute left-2.5 top-1/2 -translate-y-1/2 text-foreground-muted pointer-events-none"
@@ -42,12 +43,12 @@
           <input
             v-model.trim="fnFilter"
             placeholder="Function ID or exact name…"
-            class="h-10 w-full bg-background border border-border rounded-md pl-8 pr-3 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            class="h-7 w-full bg-background border border-border rounded-md pl-8 pr-3 text-xs text-foreground placeholder-foreground-muted focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
             @keydown.enter="refresh"
           >
         </label>
         <div
-          class="flex items-center gap-2 overflow-x-auto scrollable snap-x min-w-0"
+          class="flex items-center gap-2 overflow-x-auto scrollable swipe-x snap-x min-w-0"
           aria-label="Time range"
         >
           <Button
@@ -65,7 +66,7 @@
         </div>
       </div>
       <div
-        class="flex items-center gap-2 overflow-x-auto scrollable snap-x min-w-0"
+        class="flex items-center gap-2 overflow-x-auto scrollable swipe-x snap-x min-w-0"
         aria-label="Trace status"
       >
         <Button

--- a/frontend/src/views/Webhooks.vue
+++ b/frontend/src/views/Webhooks.vue
@@ -30,7 +30,7 @@
       class="mb-3"
     />
 
-    <div class="bg-background border border-border rounded-lg overflow-x-auto">
+    <div class="bg-background border border-border rounded-lg overflow-x-auto scrollable">
       <ul class="sm:hidden divide-y divide-border">
         <li
           v-for="sub in subscriptions"
@@ -163,7 +163,7 @@
                    the table renders at, with no other route to it. -->
               <button
                 type="button"
-                class="touch-expand-sm w-full text-left cursor-pointer rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                class="touch-expand-sm w-full text-left cursor-pointer rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                 @click="openDeliveries(sub)"
               >
                 <div class="flex flex-col">

--- a/frontend/test/aiSettingsLayout.test.js
+++ b/frontend/test/aiSettingsLayout.test.js
@@ -5,10 +5,19 @@ import { readFileSync } from 'node:fs'
 const settings = readFileSync(new URL('../src/components/ai/AISettingsPanel.vue', import.meta.url), 'utf8')
 const modelMenu = readFileSync(new URL('../src/components/ai/ModelMenu.vue', import.meta.url), 'utf8')
 const popover = readFileSync(new URL('../src/components/common/Popover.vue', import.meta.url), 'utf8')
+const filterSelect = readFileSync(new URL('../src/components/common/FilterSelect.vue', import.meta.url), 'utf8')
 
 test('active provider and model use the same field geometry', () => {
-  assert.match(settings, /id="ai-active-provider"[\s\S]*?class="[^"]*h-10 w-full[^"]*rounded-md[^"]*text-sm/)
-  assert.match(modelMenu, /wide[\s\S]*?'h-10 w-full justify-between rounded-md[^']*text-sm/)
+  // Both are the app's own picker in wide mode, which is the strongest form of
+  // "these two match": one class string, not two that happen to agree. The
+  // provider was a native <select> and the pair drifted the moment either moved.
+  assert.match(settings, /trigger-id="ai-active-provider"[\s\S]*?\bwide\b/)
+  assert.match(settings, /id="ai-active-model"[\s\S]*?:wide="true"|<ModelMenu[\s\S]*?\bwide\b/)
+  // ...and each carries the touch floor, or it is the one field on the panel
+  // that stays 38px on a phone while its neighbours reach 44.
+  assert.match(filterSelect, /'h-10 w-full justify-between px-3 text-sm touch-expand-md'/)
+  assert.match(modelMenu, /wide[\s\S]*?'[^']*\bh-10 w-full justify-between rounded-md[^']*text-sm/)
+  assert.match(modelMenu, /wide[\s\S]*?'[^']*\btouch-expand-md\b[^']*h-10 w-full/)
 })
 
 test('wide model menus fill their settings column without changing compact chat menus', () => {

--- a/frontend/test/responsive.test.js
+++ b/frontend/test/responsive.test.js
@@ -251,6 +251,17 @@ test('no colour literal stands in for a theme token', () => {
   assert.deepEqual(bad, [], `colour literals found:\n${bad.join('\n')}`)
 })
 
+test('no view opens the operating system picker', () => {
+  // A native <select> hands a phone its OS wheel, beside a FilterSelect that
+  // opens a sheet: two behaviours for one job. The app had fifteen of them.
+  const bad = []
+  for (const { file, tpl } of templates) {
+    if (file.endsWith('FilterSelect.vue')) continue
+    if (/<select[\s>]/.test(tpl)) bad.push(file)
+  }
+  assert.deepEqual(bad, [], `use FilterSelect instead of a native <select>:\n${bad.join('\n')}`)
+})
+
 test('a muted token is never faded further with alpha', () => {
   // --color-foreground-muted IS the muted step; there is nothing left to
   // spend. Measured in a browser on the real pages: placeholder text at /60

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -76,7 +76,7 @@ also accept `ORVA_ENDPOINT`/`ORVA_API_KEY` and fall back to `~/.orva/config.yaml
 ## Subdirectories
 
 - `e2e/` — comprehensive programmatic **Python (stdlib-only)** E2E suite; spins its own fresh isolated Docker container via `cd test/e2e && python3 run.py`. Covers the full server API + CLI + AI assistant and is the source-of-truth "does everything still work as spec'd" suite. See `test/e2e/CLAUDE.md`.
-- `browser/` — real-browser UI suite (Playwright over system Chrome): overflow and clipping, touch targets, accessibility, and multi-step journeys. Needs a running instance; see `test/browser/CLAUDE.md`.
+- `browser/` — real-browser UI suite (Playwright over system Chrome): overflow and clipping, touch targets, the control size ladder, cross-view control consistency, accessibility, and multi-step journeys. Needs a running instance; see `test/browser/CLAUDE.md`.
 - `container/` — end-to-end against a **real container on a throwaway Docker network**, with the privileges nsjail actually needs. Builds the image, brings the instance up, runs the API/sandbox and browser suites, and removes everything on exit. Unlike the rest of this directory it needs no running instance. See `test/container/CLAUDE.md`.
 - `cli/` — CLI-only harnesses: build matrix, install-cli, upgrade round-trip, command-tree golden diff.
 - `install/` — server-install e2e (privileged systemd-in-docker across distros + Kata flow).

--- a/test/browser/CLAUDE.md
+++ b/test/browser/CLAUDE.md
@@ -42,6 +42,7 @@ clear iOS's 16px focus-zoom threshold. Neither is visible in the class name.
 | `responsive` | nothing overflows the viewport; nothing is clipped without a scroll affordance |
 | `touch-targets` | every control clears 44×44 where the pointer is coarse |
 | `control-scale` | every control lands on the size ladder, on both pointer types |
+| `consistency` | controls agree with their neighbours: siblings, the same label across views, and the size of the radius/icon populations |
 | `accessibility` | accessible names, keyboard reachability, AA contrast, heading order, duplicate ids |
 | `journeys` | real multi-step flows (nav drawer, destructive-dialog keyboard safety) |
 
@@ -64,6 +65,37 @@ inline target), and any control whose label runs to more than one line or whose
 children are stacked blocks — a card body that happens to be a button is sized
 by its content. Two controls are exempt by name, each with its reason in the
 file.
+
+`consistency` is the answer to the question `control-scale` cannot ask. Every
+other suite here measures a control against a **standard**; none of them can see
+a **pair**. That is how the app reached 40 off-system controls, 9 radius values,
+a `Refresh` drawn at three heights with three icon sizes across six views, and a
+`Copy secret` rendered four different ways — all while 2520 assertions passed.
+`Function` at 26.6px passed. `STATUS` at 26.6px passed. That one was 10px
+uppercase beside the other at 11.4px sentence-case was invisible to both.
+
+Three relational invariants:
+
+- **Siblings in a row agree** on height, label size, case and radius. A "row" is
+  the nearest ancestor holding more than one control, because a filter strip's
+  triggers are cousins — each sits in its own `Popover` root — not siblings.
+- **The same label is drawn the same way in every view.** Accumulated across
+  routes and judged in `afterViewport`, which is why the runner has that hook:
+  the comparison cannot happen on the page where the first sighting was made.
+- **The radius and icon populations stay inside the declared sets.** Per-control
+  rules cannot catch this; the point is that the *set* stays small, and a tenth
+  radius is drift even when each one is individually defensible.
+
+**The walk stops at a table cell.** The columns of a data row are different type
+roles by design — a mono timestamp, a medium function name, a ghost action — and
+they share a line only because the row centres them. Comparing across `<td>`
+boundaries reported four defects that were not defects.
+
+Two exemption lists, each entry with its reason in the file: `ROW_EXEMPT` for a
+control that may sit in any row (the firewall switch, whose geometry *is* the
+switch), and `LABEL_EXEMPT` for a word deliberately drawn twice (the composer's
+model button is a full control when the rail is open and a bare glyph when it is
+collapsed).
 
 Layout suites run per viewport. Flow suites run once, on the widest viewport,
 because they drive interactions rather than measure layout. The accessibility

--- a/test/browser/run.mjs
+++ b/test/browser/run.mjs
@@ -7,7 +7,7 @@
 //
 //   node run.mjs --url http://127.0.0.1:8443 --api-key "$ADMIN_KEY"
 //   node run.mjs --url ... --api-key ... --destructive     # include delete flows
-//   node run.mjs --url ... --suite responsive,touch-targets
+//   node run.mjs --url ... --suite responsive,consistency
 //   node run.mjs --url ... --theme day                     # one theme, not both
 //
 // Exit codes:  0 all checks passed   1 at least one failed   2 could not start
@@ -28,9 +28,11 @@ import * as responsive from './suites/responsive.mjs'
 import * as touchTargets from './suites/touch-targets.mjs'
 import * as accessibility from './suites/accessibility.mjs'
 import * as controlScale from './suites/control-scale.mjs'
+import * as edgeGuard from './suites/edge-guard.mjs'
+import * as consistency from './suites/consistency.mjs'
 import * as journeys from './suites/journeys.mjs'
 
-const PAGE_SUITES = [smoke, responsive, touchTargets, controlScale, accessibility]
+const PAGE_SUITES = [smoke, responsive, touchTargets, controlScale, consistency, edgeGuard, accessibility]
 const FLOW_SUITES = [journeys]
 
 const BASE = arg('url', process.env.ORVA_URL || 'http://127.0.0.1:8443').replace(/\/$/, '')
@@ -164,6 +166,16 @@ try {
 
       if (SHOT_DIR) {
         await page.screenshot({ path: join(SHOT_DIR, `${theme}__${viewport.name}__${route.name}.png`) })
+      }
+    }
+
+    // A relational check needs every route in hand before it can speak.
+    for (const suite of pageSuites) {
+      if (!suite.afterViewport) continue
+      try {
+        await suite.afterViewport({ viewport, theme, report: themeReport })
+      } catch (e) {
+        themeReport.fail(suite.meta.id, viewport.name, 'suite ran', `threw: ${String(e).slice(0, 160)}`)
       }
     }
 

--- a/test/browser/suites/consistency.mjs
+++ b/test/browser/suites/consistency.mjs
@@ -1,0 +1,201 @@
+// Controls agree with their neighbours.
+//
+// Every other suite measures a control against a standard. That is how the app
+// reached 40 off-system controls, 9 radius values and a `Refresh` drawn at three
+// heights with three icon sizes across six views while 2520 assertions passed:
+// `Function` at 26.6px passed, `STATUS` at 26.6px passed, and the fact that one
+// was 10px uppercase beside the other at 11.4px sentence-case was invisible to
+// both. A standard cannot see a pair. These three checks are relational.
+
+export const meta = {
+  id: 'consistency',
+  title: 'Controls agree with their neighbours',
+}
+
+// Populations, not per-control rules: the point is that the *set* stays small.
+// A tenth radius is drift even when each one is individually defensible.
+const RADII = [0, 5.7, 7.6, 'pill']
+const ICONS = [11.4, 13.3, 15.2, 17.1, 19]
+const TOL = 1.2
+
+// A row is allowed to mix these with anything: a 36x20 switch whose geometry is
+// the switch, and the x inside a DNS chip, sized by the chip around it.
+const ROW_EXEMPT = ['rule-toggle', 'dns-chip-x']
+
+// The same word, drawn deliberately differently in two places.
+const LABEL_EXEMPT = [
+  // The composer's model button is a full control when the rail is open and a
+  // bare glyph when it is collapsed. Same label, two roles.
+  'no model',
+]
+
+const PROBE = ({ radii, icons, tol, rowExempt, labelExempt }) => {
+  const vis = (el) => {
+    const s = getComputedStyle(el)
+    if (s.display === 'none' || s.visibility === 'hidden' || s.opacity === '0') return false
+    const r = el.getBoundingClientRect()
+    return r.width > 1 && r.height > 1
+  }
+  const describe = (el) => {
+    const cls = typeof el.className === 'string'
+      ? el.className.trim().split(/\s+/).filter((c) => !/^(focus|hover|group|disabled|dark|sm:|md:|lg:)/.test(c)).slice(0, 3).join('.')
+      : ''
+    return `${el.tagName.toLowerCase()}${cls ? '.' + cls : ''}`.slice(0, 60)
+  }
+  // The label a human reads, not the wrapper's textContent: a control whose text
+  // sits three spans deep still says one word.
+  const labelOf = (el) => (el.getAttribute('aria-label') || el.textContent || '')
+    .replace(/\s+/g, ' ').trim().toLowerCase().slice(0, 32)
+  const radiusOf = (cs) => {
+    const v = parseFloat(cs.borderTopLeftRadius) || 0
+    return v > 100 ? 'pill' : v
+  }
+  const near = (v, set) => set.some((s) => s === v || (typeof s === 'number' && Math.abs(s - v) <= tol))
+
+  const sel = 'button, a[href], [role="button"], input[type=submit]'
+  const controls = []
+  for (const el of document.querySelectorAll(sel)) {
+    if (!vis(el)) continue
+    if (rowExempt.some((c) => el.classList.contains(c))) continue
+    if (el.tagName === 'A' && el.closest('p, li, td, .doc-prose, .doc-lede')) continue
+    const r = el.getBoundingClientRect()
+    if (r.height > 60) continue
+    const cs = getComputedStyle(el)
+    const lh = parseFloat(cs.lineHeight) || parseFloat(cs.fontSize) * 1.5
+    if (lh > 0 && r.height > lh * 2.2) continue
+    const container = [...el.children].some((c) => {
+      const d = getComputedStyle(c).display
+      return d === 'block' || d === 'flex' || d === 'grid'
+    })
+    if (container && r.width > 160) continue
+    // Own text, not a descendant's: what decides whether font-size is comparable.
+    const own = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim())
+      || [...el.querySelectorAll('span')].some((s) =>
+        [...s.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim()))
+    const svg = el.querySelector('svg')
+    controls.push({
+      el, r, cs,
+      h: r.height,
+      fs: parseFloat(cs.fontSize),
+      tt: cs.textTransform,
+      rad: radiusOf(cs),
+      icon: svg ? Math.round(svg.getBoundingClientRect().width * 10) / 10 : 0,
+      label: labelOf(el),
+      texted: own,
+      desc: describe(el),
+    })
+  }
+
+  const rows = []
+  const pop = []
+  const labels = []
+
+  // 1. Siblings in a row. "Row" is the nearest ancestor holding more than one
+  //    control, because a filter strip's triggers are cousins -- each sits in
+  //    its own Popover root -- not siblings.
+  //
+  //    The walk stops at a table cell. Columns of a data row are different type
+  //    roles by design -- a mono timestamp, a medium function name, a ghost
+  //    action -- and they only share a line because the row centres them.
+  const bands = new Map()
+  for (const c of controls) {
+    const cell = c.el.closest('td, th')
+    let a = c.el.parentElement
+    for (let i = 0; a && i < 6; i++) {
+      if (cell && !cell.contains(a)) { a = null; break }
+      if (controls.filter((x) => x !== c && a.contains(x.el)).length) break
+      a = a.parentElement
+    }
+    if (!a) continue
+    const key = `${a.dataset.rowKey || (a.dataset.rowKey = String(Math.random()))}|${Math.round((c.r.top + c.r.height / 2) / 4)}`
+    if (!bands.has(key)) bands.set(key, [])
+    bands.get(key).push(c)
+  }
+  for (const group of bands.values()) {
+    if (group.length < 2) continue
+    const spread = (vals) => Math.max(...vals) - Math.min(...vals)
+    const hs = group.map((c) => c.h)
+    if (spread(hs) > tol) {
+      rows.push(`row [${group.map((c) => `"${c.label.slice(0, 12)}" ${c.h.toFixed(1)}`).join(' | ')}] disagree on height`)
+      continue
+    }
+    const texted = group.filter((c) => c.texted)
+    if (texted.length > 1) {
+      if (spread(texted.map((c) => c.fs)) > 0.6) {
+        rows.push(`row [${texted.map((c) => `"${c.label.slice(0, 12)}" ${c.fs.toFixed(1)}px`).join(' | ')}] disagree on label size`)
+        continue
+      }
+      if (new Set(texted.map((c) => c.tt)).size > 1) {
+        rows.push(`row [${texted.map((c) => `"${c.label.slice(0, 12)}" ${c.tt}`).join(' | ')}] disagree on case`)
+        continue
+      }
+    }
+    const rads = [...new Set(group.map((c) => String(c.rad)))]
+    if (rads.length > 1) {
+      rows.push(`row [${group.map((c) => `"${c.label.slice(0, 12)}" ${c.rad}`).join(' | ')}] disagree on radius`)
+    }
+  }
+
+  // 2. Populations stay inside the declared sets.
+  const offRad = new Map()
+  const offIco = new Map()
+  for (const c of controls) {
+    if (!near(c.rad, radii)) offRad.set(`${c.desc} ${c.rad}`, c.label)
+    if (c.icon && !near(c.icon, icons)) offIco.set(`${c.desc} ${c.icon}px`, c.label)
+  }
+  for (const [k, v] of offRad) pop.push(`radius outside the set: ${k} "${v.slice(0, 12)}"`)
+  for (const [k, v] of offIco) pop.push(`icon size outside the set: ${k} "${v.slice(0, 12)}"`)
+
+  // 3. Handed back to the runner: the same label in another view is a separate
+  //    page, so the comparison cannot happen here.
+  for (const c of controls) {
+    if (!c.label || c.label.length < 3) continue
+    if (labelExempt.includes(c.label)) continue
+    labels.push({ label: c.label, h: c.h, fs: c.fs, icon: c.icon, desc: c.desc })
+  }
+
+  return { rows: rows.slice(0, 8), pop: pop.slice(0, 8), labels }
+}
+
+// theme|viewport|label -> first sighting, so a second one can be compared to it.
+const sightings = new Map()
+
+export async function onPage({ page, route, viewport, theme, report }) {
+  if (viewport.name !== 'laptop' && viewport.name !== 'phone') return
+
+  const { rows, pop, labels } = await page.evaluate(PROBE, {
+    radii: RADII, icons: ICONS, tol: TOL, rowExempt: ROW_EXEMPT, labelExempt: LABEL_EXEMPT,
+  })
+
+  const where = `${viewport.name} ${route.name}`
+  report.record('consistency', where, 'controls in a row agree', rows)
+  report.record('consistency', where, 'radius and icon sizes stay in the declared sets', pop)
+
+  for (const l of labels) {
+    const key = `${theme}|${viewport.name}|${l.label}`
+    const first = sightings.get(key)
+    if (!first) { sightings.set(key, { ...l, route: route.name }); continue }
+    if (first.route === route.name) continue
+    if (first.drift) continue
+    const dh = Math.abs(first.h - l.h) > TOL
+    const df = Math.abs(first.fs - l.fs) > 0.6
+    const di = first.icon !== l.icon && Math.abs(first.icon - l.icon) > TOL
+    if (dh || df || di) {
+      first.drift = `"${l.label}" is ${l.h.toFixed(1)}px/${l.fs.toFixed(1)}px/icon ${l.icon} on ${route.name}` +
+        ` but ${first.h.toFixed(1)}px/${first.fs.toFixed(1)}px/icon ${first.icon} on ${first.route}`
+      first.theme = theme
+      first.viewport = viewport.name
+    }
+  }
+}
+
+// Cross-route drift can only be judged once every route has been seen.
+export async function afterViewport({ viewport, theme, report }) {
+  if (viewport.name !== 'laptop' && viewport.name !== 'phone') return
+  const drift = []
+  for (const [key, v] of sightings) {
+    if (!key.startsWith(`${theme}|${viewport.name}|`)) continue
+    if (v.drift) drift.push(v.drift)
+  }
+  report.record('consistency', viewport.name, 'the same label is drawn the same way in every view', drift.slice(0, 10))
+}

--- a/test/browser/suites/edge-guard.mjs
+++ b/test/browser/suites/edge-guard.mjs
@@ -1,0 +1,124 @@
+// Horizontal strips do not rubber-band past their ends.
+//
+// This exists because the defect was reported from a phone three times and
+// "verified fixed" twice against a headless Chromium that cannot reproduce it.
+// Chromium clamps scrollLeft at its maximum whatever the stylesheet says, so
+// measuring the scroll position proves nothing: the strip is not moving, the
+// engine is painting an elastic overscroll on top of it.
+//
+// What IS observable on every engine is whether the touchmove was cancelled.
+// `utils/edgeGuard.js` calls preventDefault when a horizontal gesture pushes a
+// scroller that is already at that end, and a cancelled event is a fact any
+// browser will report. So the assertion is about the guard being installed and
+// firing at the ends and NOT firing in the middle -- not about pixels.
+
+export const meta = {
+  id: 'edge-guard',
+  title: 'Horizontal strips are clamped at their ends',
+}
+
+// Routes that carry a scrolling filter strip.
+const STRIPS = ['activity', 'jobs', 'traces']
+
+export async function onPage({ page, route, viewport, report }) {
+  if (!viewport.touch) return
+  if (!STRIPS.includes(route.name)) return
+  const where = `${viewport.name} ${route.name}`
+
+  const found = await page.evaluate(() => {
+    // The filter strip specifically, and only where it is genuinely a scroll
+    // container. From sm up these strips are `sm:overflow-visible` and wrap
+    // instead of scrolling, so scrollWidth still exceeds clientWidth while
+    // nothing scrolls -- picking by overflow alone found a wrapped strip at
+    // tablet width and asserted end-clamping on something with no ends.
+    const el = [...document.querySelectorAll('.swipe-x')].find((n) => {
+      const ox = getComputedStyle(n).overflowX
+      return (ox === 'auto' || ox === 'scroll') && n.scrollWidth - n.clientWidth > 1
+    })
+    if (!el) return null
+    const r = el.getBoundingClientRect()
+    return { x: r.x + Math.min(60, r.width / 4), y: r.y + r.height / 2, width: r.width }
+  })
+  // A strip that does not overflow at this width has no ends to defend.
+  if (!found) return report.skip('edge-guard', where, 'strip is clamped at both ends',
+    'the strip wraps rather than scrolls at this width')
+
+  // Instrument: record whether each touchmove came back cancelled.
+  await page.evaluate(() => {
+    window.__egCancelled = []
+    document.addEventListener('touchmove', (e) => {
+      window.__egCancelled.push(e.defaultPrevented)
+    }, { passive: true })
+  })
+
+  const cdp = await page.context().newCDPSession(page)
+  const drag = async (from, to, steps = 5) => {
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart', touchPoints: [{ x: from, y: found.y }],
+    })
+    for (let i = 1; i <= steps; i++) {
+      const x = from + ((to - from) * i) / steps
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove', touchPoints: [{ x, y: found.y }],
+      })
+      await page.waitForTimeout(30)
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+    await page.waitForTimeout(60)
+  }
+
+  const failures = []
+
+  // 1. At the start, dragging further right must be cancelled.
+  await page.evaluate(() => {
+    const el = [...document.querySelectorAll('.swipe-x')].find((n) => {
+      const ox = getComputedStyle(n).overflowX
+      return (ox === 'auto' || ox === 'scroll') && n.scrollWidth - n.clientWidth > 1
+    })
+    el.scrollLeft = 0
+    window.__egCancelled = []
+  })
+  await drag(found.x, found.x + 140)
+  const atStart = await page.evaluate(() => window.__egCancelled.some(Boolean))
+  if (!atStart) {
+    failures.push('dragging right at scrollLeft 0 was not cancelled: the strip can be ' +
+      'pulled past its first chip')
+  }
+
+  // 2. In the middle, an ordinary scroll must NOT be cancelled -- a guard that
+  //    swallows every move has broken scrolling rather than fixed bouncing.
+  await page.evaluate(() => {
+    const el = [...document.querySelectorAll('.swipe-x')].find((n) => {
+      const ox = getComputedStyle(n).overflowX
+      return (ox === 'auto' || ox === 'scroll') && n.scrollWidth - n.clientWidth > 1
+    })
+    el.scrollLeft = Math.floor((el.scrollWidth - el.clientWidth) / 2)
+    window.__egCancelled = []
+  })
+  await drag(found.x + 120, found.x + 40)
+  const midCancelled = await page.evaluate(() => window.__egCancelled.some(Boolean))
+  if (midCancelled) {
+    failures.push('a mid-range horizontal drag was cancelled: the strip cannot be scrolled')
+  }
+
+  // 3. A vertical gesture starting on the strip must never be cancelled, or the
+  //    page cannot be scrolled by anyone whose thumb lands on a filter row.
+  await page.evaluate(() => { window.__egCancelled = [] })
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchStart', touchPoints: [{ x: found.x, y: found.y }],
+  })
+  for (let i = 1; i <= 5; i++) {
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove', touchPoints: [{ x: found.x, y: found.y - i * 24 }],
+    })
+    await page.waitForTimeout(30)
+  }
+  await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] })
+  const vertCancelled = await page.evaluate(() => window.__egCancelled.some(Boolean))
+  if (vertCancelled) {
+    failures.push('a vertical drag starting on the strip was cancelled: the page cannot ' +
+      'be scrolled from a filter row')
+  }
+
+  report.record('edge-guard', where, 'strip is clamped at both ends', failures)
+}


### PR DESCRIPTION
## Why

Every check in the browser suite measured a control **against a standard**. None could see a **pair**. That is how the dashboard reached nine corner radii, `Refresh` at three heights with three icon sizes across six views, and `Copy secret` drawn four different ways — all while 2520 assertions passed. `Function` at 26.6px passed. `STATUS` at 26.6px passed. That one was 10px uppercase beside the other at 11.4px sentence-case was invisible to both.

## The enforcement

New `test/browser/suites/consistency.mjs` asserts three **relational** facts:

- controls sharing a row agree on height, label size, case and radius
- a label appearing in two views is drawn the same way in both
- the radius and icon-size populations stay inside a declared set

Cross-route comparison needs every route in hand, hence the new `afterViewport` hook in the runner. The row walk **stops at a table cell** — a data row's columns are different type roles by design, and comparing across them reported four defects that were not defects.

Each check was shown to **fail on a real defect** before being trusted to pass. Checks 1 and 3 fired on the old code; the cross-route arm was proven by injecting icon drift into a second route.

## One picker

Fifteen fields were still native `<select>`s, which hand a phone its OS wheel beside a control that opens a sheet. All are now `FilterSelect`, which grew two shapes to cover them: `bare` for the dense method bar, and `header: true` options for the template list's groups. A source guard in `responsive.test.js` fails the build if a `<select>` returns.

## Found by looking, not measuring

None of these were visible to the suites:

- Active provider was a filled violet chip; Active model right below it was an outlined field
- The invocations search box was squeezed to three characters by the chips beside it on a phone
- Five disclosures had four affordances; two had none and read as plain text
- Button labels and page headings split between sentence case and Title Case
- The DNS field clipped its own placeholder; the docs Copy button was an unlabelled square on a phone

## Verification

- **2668 checks, 0 failures** — 19 routes × 7 viewports × both themes, against the **embedded binary**, not the dev server
- `go vet` clean, 25 Go packages green, 53 frontend unit tests green, eslint clean
- All four `reference.md` copies byte-identical

## Not done, deliberately

Traces uses a 6-chip time strip where Invocations uses a Range dropdown. Both are built from the app's own primitives and agree on height and radius, but they are different *kinds* of control for the same job. Unifying them trades one-tap switching for a cleaner strip — a design decision, not a defect.