### PR TITLE
Stop advertising an image that 404s, ship the real SDK, make the gate fail closed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,9 +68,11 @@ jobs:
     steps:
       - name: resolve commit SHA for the tag
         id: sha
+        if: ${{ github.event.inputs.force != 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
             TAG="${{ github.event.inputs.tag }}"
           else
@@ -80,8 +82,14 @@ jobs:
             echo "::error::release tag must use stable date format vYYYY.MM.DD"
             exit 1
           }
-          SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq .sha 2>/dev/null || true)"
-          [ -n "$SHA" ] || { echo "::error::could not resolve a commit SHA to gate on"; exit 1; }
+          # gh prints its error body on stdout, so a failed call is caught by SHA shape, not emptiness.
+          deadline=$((SECONDS + 120))  # ~2 min cap
+          while :; do
+            SHA="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${TAG}" --jq .sha || true)"
+            if [[ "$SHA" =~ ^[0-9a-f]{40,64}$ ]]; then break; fi
+            [ $SECONDS -lt $deadline ] || { echo "::error::$TAG did not resolve to a commit SHA — see the gh errors above"; exit 1; }
+            echo "… $TAG has not resolved to a commit yet — retrying"; sleep 10
+          done
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
           echo "gating on commit $SHA"
 
@@ -103,9 +111,15 @@ jobs:
           check() {
             local wf="$1" mode="$2" deadline=$((SECONDS + 1200))  # ~20 min cap
             while :; do
+              # gh prints its error body on stdout, so an unreadable status must be caught by shape.
               read -r status conclusion < <(gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/workflows/${wf}/runs?head_sha=${SHA}&event=push&branch=main&per_page=1" \
-                --jq '.workflow_runs[0] | "\(.status) \(.conclusion)"' 2>/dev/null || echo "null null")
+                --jq '.workflow_runs[0] | "\(.status) \(.conclusion)"' || echo "api_error null")
+              case "$status" in
+                null|queued|in_progress|requested|waiting|pending|completed) ;;
+                *) [ $SECONDS -lt $deadline ] || { echo "::error::could not read $wf status for $SHA — see the gh errors above"; return 1; }
+                   echo "… $wf status for $SHA is unreadable — retrying"; sleep 20; continue ;;
+              esac
               if [ "$status" = "null" ]; then
                 if [ "$mode" = "soft" ]; then echo "• $wf: no run for $SHA (path-filtered) — skipping"; return 0; fi
                 echo "::error::no $wf run for $SHA — commit was not verified (use force=true to override)"; return 1
@@ -690,6 +704,7 @@ jobs:
             VERSION=${{ steps.v.outputs.tag }}
             COMMIT=${{ steps.v.outputs.commit }}
             BUILD_TIME=${{ steps.v.outputs.build_time }}
+            IMAGE_REF=${{ env.IMAGE_NAME }}:latest
             NSJAIL_REF=${{ env.NSJAIL_REF }}
           outputs: type=image,name=${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,27 @@ before it.
 
 ## Unreleased
 
-Nothing yet.
+### Fixed
+
+- **The dashboard offered a container image tag that does not exist.** Settings
+  → Build info showed `ghcr.io/harsh-2002/orva:<version>` with a copy button,
+  but Orva publishes exactly one image tag, `:latest`; every per-version tag
+  404s on `docker pull`, and a bare-metal install has no image at all.
+  `/api/v1/system/health` now reports the image the deployment actually runs
+  from — the published image stamps it, the shipped compose file passes through
+  whatever it pulled — and reports it empty otherwise, where the dashboard hides
+  the row. If you script on that field, it is now empty on bare-metal and
+  self-built deployments; `version` remains the build identity.
+
+- **The Docker image shipped an incomplete `orva` SDK.** The image's rootfs
+  stage copied `orva.js` in under the name `index.js` and hand-wrote its own
+  `package.json` claiming version `0.2.0` — five SDK releases stale — while
+  omitting `orva.d.ts` and Python's `py.typed` entirely. The bare-metal
+  installer never had this problem: `orva setup` installs the SDK from the
+  binary's embedded copy, under the real filenames. Docker deployments now get
+  the same files. Nothing an operator does changes; on the next container start
+  the entrypoint replaces the SDK directory in a persistent volume, which also
+  clears the stale `index.js` an older image left there.
 
 ## v2026.08.28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,9 +50,12 @@ FROM node:24-slim AS rootfs-node
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc /usr/share/man /usr/share/locale \
     && mkdir -p /opt/orva /opt/orva/node_modules/orva /code
-COPY backend/runtimes/node/adapter.js /opt/orva/adapter.js
-COPY backend/runtimes/node/orva.js    /opt/orva/node_modules/orva/index.js
-RUN echo '{"name":"orva","version":"0.2.0","main":"index.js"}' > /opt/orva/node_modules/orva/package.json
+# The SDK's own package.json is canonical (main ./orva.js, types ./orva.d.ts),
+# so every file must keep its real name — a rename here breaks `main`.
+COPY backend/runtimes/node/adapter.js   /opt/orva/adapter.js
+COPY backend/runtimes/node/orva.js      /opt/orva/node_modules/orva/orva.js
+COPY backend/runtimes/node/orva.d.ts    /opt/orva/node_modules/orva/orva.d.ts
+COPY backend/runtimes/node/package.json /opt/orva/node_modules/orva/package.json
 
 FROM python:3.14-slim AS rootfs-python
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
@@ -62,11 +65,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && mkdir -p /opt/orva /code
 COPY backend/runtimes/python/adapter.py /opt/orva/adapter.py
 COPY backend/runtimes/python/orva.py    /opt/orva/orva.py
+COPY backend/runtimes/python/py.typed   /opt/orva/py.typed
 
 FROM debian:bookworm-slim
 ARG VERSION
 ARG COMMIT
 ARG BUILD_TIME
+ARG IMAGE_REF
 
 LABEL org.opencontainers.image.title="Orva" \
       org.opencontainers.image.description="Self-hosted serverless function platform — Node.js + Python on nsjail" \
@@ -98,6 +103,9 @@ WORKDIR /var/lib/orva
 EXPOSE 8443
 
 ENV ORVA_DATA_DIR=/var/lib/orva
+# Only the publishing pipeline knows the reference this image is pushed under;
+# unset (any local build) makes /system/health report no image, not a wrong one.
+ENV ORVA_IMAGE=${IMAGE_REF}
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
     CMD curl -fsS http://localhost:8443/api/v1/system/health || exit 1

--- a/backend/cmd/orva/setup.go
+++ b/backend/cmd/orva/setup.go
@@ -301,20 +301,26 @@ func installAdapter(rootfs, runtime string) error {
 	return installSDK(rootfs, runtime)
 }
 
+// sdkFiles and sdkDestDir are the in-sandbox SDK layout. The Dockerfile
+// bakes the same layout into its rootfs stages; setup_test.go pins the two
+// against each other.
+var (
+	sdkFiles = map[string][]string{
+		"node":   {"orva.js", "orva.d.ts", "package.json"},
+		"python": {"orva.py", "py.typed"},
+	}
+	sdkDestDir = map[string]string{
+		"node":   "opt/orva/node_modules/orva",
+		"python": "opt/orva",
+	}
+)
+
 func installSDK(rootfs, runtime string) error {
-	var files []string
-	var destSub string
-	switch runtime {
-	case "node":
-		files = []string{"orva.js", "orva.d.ts", "package.json"}
-		destSub = "opt/orva/node_modules/orva"
-	case "python":
-		files = []string{"orva.py", "py.typed"}
-		destSub = "opt/orva"
-	default:
+	files, ok := sdkFiles[runtime]
+	if !ok {
 		return nil
 	}
-	dstDir := filepath.Join(rootfs, destSub)
+	dstDir := filepath.Join(rootfs, sdkDestDir[runtime])
 	if err := os.MkdirAll(dstDir, 0o755); err != nil {
 		return fmt.Errorf("mkdir %s: %w", dstDir, err)
 	}

--- a/backend/cmd/orva/setup_test.go
+++ b/backend/cmd/orva/setup_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -40,5 +43,67 @@ func TestRuntimeCompleteRequiresExecutable(t *testing.T) {
 	}
 	if runtimeComplete(entrypoint) {
 		t.Fatal("non-executable runtime entrypoint was accepted")
+	}
+}
+
+// TestEmbeddedNodeSDKEntrypointsExist pins package.json's main/types against
+// the files actually embedded. A `main` that misses does not fail loudly —
+// Node falls back to index.js under DEP0128 — so nothing else would notice.
+func TestEmbeddedNodeSDKEntrypointsExist(t *testing.T) {
+	raw, err := embeddedAdapters.ReadFile("adapters/node/package.json")
+	if err != nil {
+		t.Fatalf("read embedded node package.json: %v", err)
+	}
+	var pkg struct {
+		Main  string `json:"main"`
+		Types string `json:"types"`
+	}
+	if err := json.Unmarshal(raw, &pkg); err != nil {
+		t.Fatalf("parse embedded node package.json: %v", err)
+	}
+	for field, rel := range map[string]string{"main": pkg.Main, "types": pkg.Types} {
+		if rel == "" {
+			t.Errorf("package.json %q is empty", field)
+			continue
+		}
+		name := strings.TrimPrefix(rel, "./")
+		if _, err := embeddedAdapters.ReadFile("adapters/node/" + name); err != nil {
+			t.Errorf("package.json %q = %q but adapters/node/%s is not embedded: %v", field, rel, name, err)
+		}
+	}
+}
+
+// TestDockerfileShipsTheSDKUnderItsRealNames keeps the image's rootfs stages
+// in step with installSDK. The image once renamed orva.js to index.js and
+// hand-wrote a package.json that had gone five SDK versions stale.
+func TestDockerfileShipsTheSDKUnderItsRealNames(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	lines := strings.Split(string(raw), "\n")
+	for rt, files := range sdkFiles {
+		copied := map[string]string{} // in-image path -> source basename
+		for _, line := range lines {
+			f := strings.Fields(line)
+			if len(f) != 3 || f[0] != "COPY" {
+				continue
+			}
+			if !strings.HasPrefix(f[1], "backend/runtimes/"+rt+"/") {
+				continue
+			}
+			copied[f[2]] = path.Base(f[1])
+		}
+		for _, name := range files {
+			dst := "/" + sdkDestDir[rt] + "/" + name
+			src, ok := copied[dst]
+			if !ok {
+				t.Errorf("%s: Dockerfile copies nothing to %s", rt, dst)
+				continue
+			}
+			if src != name {
+				t.Errorf("%s: %s is copied from %s — renaming breaks package.json main/types", rt, dst, src)
+			}
+		}
 	}
 }

--- a/backend/internal/mcp/reference.md
+++ b/backend/internal/mcp/reference.md
@@ -190,7 +190,9 @@ The bundled `orva` module is a stdlib-only wrapper over Orva's loopback
 API. It ships beside the runtime adapter — `require('orva')` (Node) and
 `from orva import …` (Python) work without `npm install` / `pip
 install`. The Node SDK ships TypeScript declarations (`orva.d.ts`); the
-Python SDK ships a `py.typed` marker so IDEs surface full type hints.
+Python SDK ships a `py.typed` marker so IDEs surface full type hints. A
+TypeScript handler must map the module in `tsconfig.json` before `tsc` can
+see those declarations — see the TypeScript section of `docs/RUNTIMES.md`.
 
 Surface, as of v0.7:
 

--- a/backend/internal/server/handlers/system.go
+++ b/backend/internal/server/handlers/system.go
@@ -158,17 +158,14 @@ func (h *SystemHandler) Health(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// v0.7: surface the full build identity so Settings → Build info has
-	// what it needs in one round trip. `image` is derived from Version so
-	// operators can copy "ghcr.io/harsh-2002/orva:v2026.05.15" straight
-	// out of the dashboard. Unstamped binaries render as ":dev" which is
-	// honest about not being from a release.
+	// Only a container image stamps ORVA_IMAGE: the release publishes one tag
+	// (:latest) and bare metal has none, so a Version-derived ref would 404.
 	resp := map[string]any{
 		"status":         overall,
 		"version":        version.Version,
 		"commit":         version.Commit,
 		"build_time":     version.BuildTime,
-		"image":          "ghcr.io/harsh-2002/orva:" + version.Version,
+		"image":          os.Getenv("ORVA_IMAGE"),
 		"uptime_seconds": int(uptime),
 		"database": map[string]any{
 			"status": dbStatus,

--- a/backend/internal/server/handlers/system_health_test.go
+++ b/backend/internal/server/handlers/system_health_test.go
@@ -81,3 +81,26 @@ func TestHealthDBDownReturns503(t *testing.T) {
 		t.Errorf("status = %v, want degraded", body["status"])
 	}
 }
+
+// TestHealthImageOnlyWhenStamped pins `image` to what the deployment actually
+// runs from: the release publishes one tag (:latest) and bare metal has no
+// image, so a Version-derived reference is unpullable.
+func TestHealthImageOnlyWhenStamped(t *testing.T) {
+	t.Run("unstamped reports nothing", func(t *testing.T) {
+		t.Setenv("ORVA_IMAGE", "")
+		h := &SystemHandler{DB: newTestDB(t), StartTime: time.Now()}
+		_, body := callHealth(t, h)
+		if body["image"] != "" {
+			t.Errorf("image = %q, want empty (there is no image to pull)", body["image"])
+		}
+	})
+
+	t.Run("stamped reports the stamp", func(t *testing.T) {
+		t.Setenv("ORVA_IMAGE", "ghcr.io/harsh-2002/orva:latest")
+		h := &SystemHandler{DB: newTestDB(t), StartTime: time.Now()}
+		_, body := callHealth(t, h)
+		if body["image"] != "ghcr.io/harsh-2002/orva:latest" {
+			t.Errorf("image = %q, want the stamped reference", body["image"])
+		}
+	})
+}

--- a/cli/commands/reference.md
+++ b/cli/commands/reference.md
@@ -190,7 +190,9 @@ The bundled `orva` module is a stdlib-only wrapper over Orva's loopback
 API. It ships beside the runtime adapter — `require('orva')` (Node) and
 `from orva import …` (Python) work without `npm install` / `pip
 install`. The Node SDK ships TypeScript declarations (`orva.d.ts`); the
-Python SDK ships a `py.typed` marker so IDEs surface full type hints.
+Python SDK ships a `py.typed` marker so IDEs surface full type hints. A
+TypeScript handler must map the module in `tsconfig.json` before `tsc` can
+see those declarations — see the TypeScript section of `docs/RUNTIMES.md`.
 
 Surface, as of v0.7:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   orva:
-    image: ${ORVA_IMAGE:-ghcr.io/harsh-2002/orva:latest}
+    image: &image ${ORVA_IMAGE:-ghcr.io/harsh-2002/orva:latest}
     # Pull rather than build. This file is meant to be downloadable on its own --
     # the README tells operators to curl it into an empty directory -- and with a
     # build section present Compose would otherwise try to build from a context
@@ -60,6 +60,9 @@ services:
     environment:
       ORVA_WRITE_TIMEOUT_SEC: "90"
       ORVA_SESSION_DAYS: "30"
+      # Aliases the image key above so health always reports the reference
+      # this stack actually runs; the two cannot drift into different names.
+      ORVA_IMAGE: *image
       # ORVA_SECURE_COOKIES is deliberately not set. This file publishes plain
       # HTTP on 3000, and a Secure cookie is not stored over http:// on
       # anything but localhost -- forcing it here logs out every operator who

--- a/docs/API.md
+++ b/docs/API.md
@@ -526,7 +526,9 @@ Cascade — removes the channel and every junction row.
 ### `GET /api/v1/system/health`
 Returns 200 and `{"status": "healthy", ...}` when orvad is up, alongside
 `version`, `commit`, `build_time`, `image`, `uptime_seconds`, and `database`,
-`sandbox`, `host` and `writer` sub-objects. Returns **503** with
+`sandbox`, `host` and `writer` sub-objects. `image` echoes the `ORVA_IMAGE`
+stamp — the published container image sets it; a bare-metal install has no
+image and reports it empty. Returns **503** with
 `{"status": "degraded"}` when the 2-second database ping fails. Used by Docker
 HEALTHCHECK and load balancers — match on `healthy`, not `ok`.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -30,7 +30,8 @@ names that stopped doing anything are deleted rather than deprecated.
 | `ORVA_TRUSTED_PROXY` | `false` | Set to `true` only when a reverse proxy in front of Orva sets `X-Forwarded-For`. It makes Orva trust that header for the OAuth dynamic-registration rate limiter's client identity. Leave it off otherwise: trusting a client-settable header would let a caller bypass that limit by varying one value per request. |
 | `ORVA_SESSION_DAYS` | `7` | Session cookie lifetime in days. Single-operator instances can set this to `30`. |
 | `ORVA_PPROF_ADDR` | (unset) | When set (e.g. `127.0.0.1:6060`), starts a Go `net/http/pprof` debug listener on that address. Bind to loopback only — it exposes goroutine/heap profiles. Off by default. |
-| `ORVA_PPROF_ADDR`, `ORVA_INTERNAL_API_BASE` are read directly where they are used rather than through the config loader, so they do **not** appear in that startup line. They still work. | |
+| `ORVA_IMAGE` | (set by the container image) | The image reference this instance runs from, echoed at `GET /api/v1/system/health` and in Settings → Build info. The published image stamps it; set it yourself only for a mirrored or re-tagged copy. A bare-metal install leaves it unset and reports no image. |
+| `ORVA_PPROF_ADDR`, `ORVA_INTERNAL_API_BASE`, `ORVA_IMAGE` are read directly where they are used rather than through the config loader, so they do **not** appear in that startup line. They still work. | |
 | `ORVA_INTERNAL_API_BASE` | (auto-detected) | The base URL sandboxed functions use to reach Orva's own internal SDK endpoints (KV, jobs, function-to-function). Orva probes for a routable address at startup — from inside a sandbox `127.0.0.1` is the sandbox's own loopback, so this is deliberately **not** a loopback address. Set it only on network setups the probe gets wrong (overlay networks, Swarm, k8s), as `http://host:port`. The compiled egress policy emits a narrow allow rule for exactly this address and port, so an operator blocking private ranges does not cut off the SDK. |
 
 ---
@@ -217,7 +218,7 @@ The server binary stamps three values at link time and exposes them at `GET /api
 | `version`    | git tag (release) or `git describe` (dev)       | `v2026.05.15` |
 | `commit`     | short git SHA at build time                     | `1be3399` |
 | `build_time` | wall-clock RFC3339 UTC at link time             | `2026-05-15T14:20:34Z` |
-| `image`      | derived: `ghcr.io/harsh-2002/orva:` + version   | `ghcr.io/harsh-2002/orva:latest` |
+| `image`      | `ORVA_IMAGE`, stamped into the published image  | `ghcr.io/harsh-2002/orva:latest`, empty on bare metal |
 
 Override at build time:
 
@@ -228,3 +229,5 @@ make build VERSION=v2026.05.15 \
 ```
 
 Container images carry the same identity as OCI labels (`org.opencontainers.image.{version,revision,created}`) so `docker inspect` agrees with the running server's `/api/v1/system/health` response. Unstamped binaries report `"dev"` / `"unknown"` — an intentional signal that the build chain wasn't wired through.
+
+Orva publishes exactly **one** image tag, `:latest` — there is no per-version image tag, and pruning removes any that appear — so nothing derives a pullable reference from `version`. `image` reports whatever `ORVA_IMAGE` holds, and nothing when it is unset.

--- a/docs/RUNTIMES.md
+++ b/docs/RUNTIMES.md
@@ -62,6 +62,21 @@ The file you authored stays in `entrypoint`; the compiled file the worker
 actually loads is recorded separately in `run_entrypoint`. You never set
 `run_entrypoint` yourself — deploy and rollback both derive it.
 
+The bundled `orva` SDK is **not** on `tsc`'s module path. It lives at
+`/opt/orva/node_modules/orva/`, and TypeScript only walks `node_modules`
+upward from your sources under `/code`, so `import { kv } from 'orva'` fails
+the build with `TS2307: Cannot find module 'orva'`. Point `paths` at the
+declarations the runtime ships:
+
+```json
+{ "compilerOptions": { "module": "commonjs", "baseUrl": ".",
+  "paths": { "orva": ["/opt/orva/node_modules/orva/orva.d.ts"] } } }
+```
+
+Keep `module: commonjs`. `tsc` then emits `require('orva')`, which the adapter
+resolves at runtime; an ESM emit leaves a bare `import`, and the adapter patches
+only Node's CommonJS resolver.
+
 ## Handler shape — Node.js
 
 ```js

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -190,7 +190,9 @@ The bundled `orva` module is a stdlib-only wrapper over Orva's loopback
 API. It ships beside the runtime adapter — `require('orva')` (Node) and
 `from orva import …` (Python) work without `npm install` / `pip
 install`. The Node SDK ships TypeScript declarations (`orva.d.ts`); the
-Python SDK ships a `py.typed` marker so IDEs surface full type hints.
+Python SDK ships a `py.typed` marker so IDEs surface full type hints. A
+TypeScript handler must map the module in `tsconfig.json` before `tsc` can
+see those declarations — see the TypeScript section of `docs/RUNTIMES.md`.
 
 Surface, as of v0.7:
 

--- a/frontend/public/docs.md
+++ b/frontend/public/docs.md
@@ -190,7 +190,9 @@ The bundled `orva` module is a stdlib-only wrapper over Orva's loopback
 API. It ships beside the runtime adapter — `require('orva')` (Node) and
 `from orva import …` (Python) work without `npm install` / `pip
 install`. The Node SDK ships TypeScript declarations (`orva.d.ts`); the
-Python SDK ships a `py.typed` marker so IDEs surface full type hints.
+Python SDK ships a `py.typed` marker so IDEs surface full type hints. A
+TypeScript handler must map the module in `tsconfig.json` before `tsc` can
+see those declarations — see the TypeScript section of `docs/RUNTIMES.md`.
 
 Surface, as of v0.7:
 

--- a/frontend/src/utils/aiPrompts.js
+++ b/frontend/src/utils/aiPrompts.js
@@ -22,7 +22,7 @@ Orva is a self-hosted serverless platform — think Cloudflare Workers / Vercel 
 <runtimes>
 Pick exactly one — Orva has no Docker, no buildpacks, no per-function version pinning. Two runtimes, generic ids, latest-stable only:
 - python (Python 3.14) — entry: handler.py — deps: requirements.txt
-- node (Node.js 24, also runs TypeScript) — entry: handler.js — deps: package.json
+- node (Node.js 24, also runs TypeScript) — entry: handler.js — deps: package.json. In TypeScript reach the SDK with require('orva'), never an ESM import: the module lives outside /code so tsc cannot resolve it, and the adapter patches only Node's CommonJS resolver.
 Native modules (psycopg2-binary, sharp, bcrypt, etc.) are supported via prebuilt wheels / npm prebuilts; if a dep needs a system library not present in the runtime image, the build will fail with a clear error.
 </runtimes>
 

--- a/frontend/src/views/Settings.vue
+++ b/frontend/src/views/Settings.vue
@@ -44,28 +44,31 @@
           {{ formatBuildTime(buildInfo?.buildTime) }}
         </dd>
 
-        <dt class="text-foreground-muted">
-          Image
-        </dt>
-        <dd class="font-mono text-foreground-strong flex items-center gap-2 min-w-0">
-          <span class="truncate">{{ buildInfo?.image || EMPTY }}</span>
-          <!-- p-1 around a 13px icon lands at 21x21 on a phone. touch-expand-*
-               grows the real box on coarse pointers only; a button centres its
-               own content, so the glyph stays put. -->
-          <button
-            v-if="buildInfo?.image"
-            class="p-1 rounded-md hover:bg-surface text-foreground-muted hover:text-foreground-strong transition-colors shrink-0 touch-expand-iconbtn"
-            title="Copy image reference"
-            aria-label="Copy image reference"
-            @click="copyImage"
-          >
-            <Copy class="w-3.5 h-3.5" />
-          </button>
-          <span
-            v-if="imageCopied"
-            class="text-xs text-primary-hover shrink-0"
-          >copied</span>
-        </dd>
+        <!-- Only a container deployment has an image; a bare-metal install
+             reports none, and an empty row with a copy button is worse. -->
+        <template v-if="buildInfo?.image">
+          <dt class="text-foreground-muted">
+            Image
+          </dt>
+          <dd class="font-mono text-foreground-strong flex items-center gap-2 min-w-0">
+            <span class="truncate">{{ buildInfo.image }}</span>
+            <!-- p-1 around a 13px icon lands at 21x21 on a phone. touch-expand-*
+                 grows the real box on coarse pointers only; a button centres its
+                 own content, so the glyph stays put. -->
+            <button
+              class="p-1 rounded-md hover:bg-surface text-foreground-muted hover:text-foreground-strong transition-colors shrink-0 touch-expand-iconbtn"
+              title="Copy image reference"
+              aria-label="Copy image reference"
+              @click="copyImage"
+            >
+              <Copy class="w-3.5 h-3.5" />
+            </button>
+            <span
+              v-if="imageCopied"
+              class="text-xs text-primary-hover shrink-0"
+            >copied</span>
+          </dd>
+        </template>
       </dl>
     </details>
 

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -12,7 +12,7 @@ Support scripts for deployment and installation. None of these are called by the
 
 ## Gotchas
 
-- `entrypoint.sh` **always overwrites** `adapter.js` / `adapter.py` from the image on every container start — this ensures runtime upgrades roll out even when the user mounts a persistent `orva-data` volume.
+- `entrypoint.sh` **always overwrites** `adapter.js` / `adapter.py` from the image on every container start — this ensures runtime upgrades roll out even when the user mounts a persistent `orva-data` volume. The bundled SDK is *replaced*, not merged: `opt/orva/node_modules/orva/` is removed and re-copied, because a merge would leave files an older image shipped under names the current one no longer uses (`index.js`) alive in the volume forever.
 - `install.sh` embeds the systemd/OpenRC units and `uninstall.sh`; the bare-metal install writes them to `$PREFIX/share/orva/scripts/` and the generated uninstaller to the same path. Edit the heredocs in `install.sh` — there is no separate unit file.
 - `install.sh --cli-only` installs only the `orva` CLI binary to `/usr/local/bin/orva` — no systemd unit, no rootfs, no service user. Use this on operator laptops or CI runners that talk to a remote Orva over HTTPS.
 - Mode/option precedence is flag > env > interactive prompt > default. Key knobs: `--version`/`ORVA_VERSION` (pin a release), `--dry-run`/`ORVA_INSTALL_DRYRUN=1` (detect only), `--no-pkg`/`ORVA_NO_PKG=1` (skip system packages), `--runtime`/`ORVA_DOCKER_RUNTIME` (force the Docker runtime). There is **no** checksum-bypass env var (no `ORVA_SKIP_VERIFY` or similar).

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -30,6 +30,9 @@ rt=node
 mkdir -p "$VOLUME_ROOTFS/$rt/opt/orva"
 cp "$IMAGE_ROOTFS/$rt/opt/orva/adapter.js" "$VOLUME_ROOTFS/$rt/opt/orva/adapter.js"
 if [ -d "$IMAGE_ROOTFS/$rt/opt/orva/node_modules/orva" ]; then
+  # Replace rather than merge: older images shipped orva.js under the name
+  # index.js, and a merge would leave that stale copy in the volume forever.
+  rm -rf "$VOLUME_ROOTFS/$rt/opt/orva/node_modules/orva"
   mkdir -p "$VOLUME_ROOTFS/$rt/opt/orva/node_modules/orva"
   cp -a "$IMAGE_ROOTFS/$rt/opt/orva/node_modules/orva/." "$VOLUME_ROOTFS/$rt/opt/orva/node_modules/orva/"
 fi
@@ -38,6 +41,9 @@ mkdir -p "$VOLUME_ROOTFS/$rt/opt/orva"
 cp "$IMAGE_ROOTFS/$rt/opt/orva/adapter.py" "$VOLUME_ROOTFS/$rt/opt/orva/adapter.py"
 if [ -f "$IMAGE_ROOTFS/$rt/opt/orva/orva.py" ]; then
   cp "$IMAGE_ROOTFS/$rt/opt/orva/orva.py" "$VOLUME_ROOTFS/$rt/opt/orva/orva.py"
+fi
+if [ -f "$IMAGE_ROOTFS/$rt/opt/orva/py.typed" ]; then
+  cp "$IMAGE_ROOTFS/$rt/opt/orva/py.typed" "$VOLUME_ROOTFS/$rt/opt/orva/py.typed"
 fi
 
 mkdir -p /var/lib/orva/functions


### PR DESCRIPTION
Three defects a release pre-flight audit surfaced. None is caused by v2026.08.28 — all three predate it.

## 1. The dashboard offered an unpullable image

`system.go` built `ghcr.io/harsh-2002/orva:<version>` and Settings gave it a **copy button**, but `release.yml` has pushed only `:latest` since eeb7ee8 (2026-05-30), and `cleanup-ghcr` prunes anything else. Verified live against GHCR: the tag list is exactly `["latest"]`; `manifests/v2026.08.28` → 404.

`:latest` isn't the fix either — a bare-metal install runs **no image at all**, and `Makefile`'s `git describe` VERSION meant `make build` stamped `...:v2026.08.28-3-gbc51148-dirty`.

The published image now stamps `ORVA_IMAGE` with the reference it was actually pushed under; `docker-compose.yml` aliases its own `image:` key with a YAML anchor so the two can't drift into different names; everything else reports empty — which the dashboard already rendered as an em dash with the copy button hidden.

```
unstamped:  {"image":"","version":"v2026.08.28-dirty"}
stamped:    {"image":"ghcr.io/harsh-2002/orva:latest","version":"v2026.08.28-dirty"}
```

## 2. The Docker image shipped a stale, incomplete SDK

The rootfs stage renamed `orva.js` → `index.js`, hand-wrote `{"version":"0.2.0"}` against a canonical `0.7.0`, and never copied `orva.d.ts` or Python's `py.typed`.

**The obvious fix is a trap.** Copying the real `package.json` while leaving the file named `index.js` does not fail loudly — Node's `LOAD_AS_DIRECTORY` falls back to `index.js` and emits `DEP0128` into every function's stderr, resting on a deprecation slated for removal. Reproduced under real Node with a control:

| Combination | Result |
|---|---|
| current (`main: index.js` + `index.js`) | works |
| canonical `package.json` + `index.js` | works, **but `DEP0128` into every function's stderr** |
| canonical `package.json` + real filenames | works, clean |

The filename and the `package.json` have to move together — which is exactly what `installSDK` in `setup.go` already does for bare metal. The Dockerfile now agrees with it, and `setup_test.go` pins the two against each other so they can't drift again. `entrypoint.sh` refreshes the SDK directory so a persistent volume doesn't keep a stale `index.js` alive across the upgrade.

Shipping `orva.d.ts` finally makes TypeScript typing work, so the docs now carry the `tsconfig` `paths` mapping it needs (the SDK lives outside `/code`, so `tsc` can't find it otherwise).

## 3. The release gate could pass on a garbage SHA

`gh api --jq` writes its error body to **stdout** and exits 1. So in:

```bash
SHA="$(gh api ... --jq .sha 2>/dev/null || true)"
[ -n "$SHA" ] || { echo "::error::..."; exit 1; }
```

`|| true` discarded the exit code, `2>/dev/null` discarded the reason, and `$SHA` was **non-empty** — holding the JSON error body — so the guard passed and the gate proceeded on garbage.

Resolution is now shape-checked (`^[0-9a-f]{40,64}$`) with a bounded retry, the sibling status loop gets the same treatment, and both surface `gh`'s own error instead of swallowing it. The resolve step also gains the `force != 'true'` guard its only consumer already had — without it, the documented emergency override aborted on the very lookup it exists to bypass.

## Verification

- Both new tests confirmed to **fail on the old code first**. The Dockerfile test names all three missing files; the health test fails on both subtests.
- `go vet` clean, 25 Go packages green, 53 frontend unit tests green, eslint clean, shellcheck clean.
- `docker-compose.yml` and `release.yml` parse as YAML; compose resolves `ORVA_IMAGE` correctly with and without the env var.
- All four `reference.md` copies byte-identical after `make docs-embed`.
- Runtime behaviour verified against the built binary, both stamped and unstamped.

Docs move with the change per `CONTRACT.md` §6a: `API.md` + `CONFIG.md` (health field, new `ORVA_IMAGE`), `RUNTIMES.md` + `reference.md` and its three copies + `aiPrompts.js` (the tsconfig mapping), `scripts/CLAUDE.md` (entrypoint).