### PR TITLE
Fix six documentation examples that shipped code which does not run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,23 @@ before it.
   operator their instance was empty when the request had simply failed. It now
   shows the same load-failure banner, with the server's message and a Retry, that
   the jobs, cron, webhooks, activity and API-key lists already used.
+- **Documentation that shipped code which does not run.** Six examples were
+  wrong, in the four places a function author actually reads: the canonical
+  reference (and its three embedded copies), the dashboard's Docs page, the
+  editor's Handler reference modal, and the prompt the in-product assistant
+  generates code from. The cron API example named its request field with a UUID
+  instead of `cron_expr`, so the documented `curl` always returned 400. The
+  Python `jobs.enqueue` example used a UUID as a variable name and was a literal
+  `SyntaxError`. The function-to-function and jobs examples indexed
+  `event.body` as if the platform had parsed it — Python raised and returned
+  500, Node silently sent an empty payload, which is worse. `event.body` has
+  always been the raw request body as a string, and every one of these now says
+  so and parses it. `docs/RUNTIMES.md` also promised `event.rawPath` and
+  `event.httpMethod` aliases that neither adapter has ever provided; the promise
+  is gone rather than the aliases added, because the event shape is a contract.
+  Two MCP tool schemas claimed job and schedule ids arrive prefixed `job_` /
+  `cron_`; both are bare UUIDv7s, and that description ships to every connected
+  agent.
 
 - **On Alpine, a successful `orva backup restore` left the server down
   permanently.** `orva backup restore` exits 70 on purpose so its supervisor

--- a/backend/internal/mcp/reference.md
+++ b/backend/internal/mcp/reference.md
@@ -266,13 +266,17 @@ exports.handler = async (event) => {
 ### F2F — Python
 
 ```python
+import json
+
 from orva import invoke, OrvaError
 
 def handler(event):
+    # event["body"] is the raw request body, as a string. Always parse it.
+    url = json.loads(event["body"] or "{}")["url"]
     try:
         # invoke() returns the downstream {statusCode, headers, body}.
         # body is JSON-decoded when possible.
-        result = invoke("resize-image", {"url": event["body"]["url"]})
+        result = invoke("resize-image", {"url": url})
         return {"statusCode": 200, "body": result["body"]}
     except OrvaError as e:
         # 404 = function not found, 507 = call depth exceeded.
@@ -285,8 +289,10 @@ def handler(event):
 const { invoke, OrvaError } = require('orva')
 
 exports.handler = async (event) => {
+  // event.body is the raw request body, as a string. Always parse it.
+  const { url } = JSON.parse(event.body || '{}')
   try {
-    const result = await invoke('resize-image', { url: event.body.url })
+    const result = await invoke('resize-image', { url })
     return { statusCode: 200, body: result.body }
   } catch (e) {
     if (e instanceof OrvaError) {
@@ -302,18 +308,21 @@ exports.handler = async (event) => {
 ### Jobs — Python
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    # Fire-and-forget. Returns the job id immediately; the function
-    # body runs later via the scheduler. max_attempts retries with
+    # Fire-and-forget. Returns {"id": ..., "replayed": ...} immediately;
+    # the body runs later via the scheduler. max_attempts retries with
     # exponential backoff on 5xx / exception.
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    body = json.loads(event["body"] or "{}")
+    job = jobs.enqueue(
         "send-welcome-email",
-        {"to": event["body"]["email"]},
+        {"to": body["email"]},
         max_attempts=3,
     )
-    return {"statusCode": 202, "body": 019df210-7b00-7e00-9c00-aab1cd2e3f43}
+    return {"statusCode": 202, "body": job}
 ```
 
 ### Jobs — Node.js
@@ -322,12 +331,13 @@ def handler(event):
 const { jobs } = require('orva')
 
 exports.handler = async (event) => {
-  const jobId = await jobs.enqueue(
+  const { email } = JSON.parse(event.body || '{}')
+  const job = await jobs.enqueue(
     'send-welcome-email',
-    { to: event.body.email },
+    { to: email },
     { maxAttempts: 3 }
   )
-  return { statusCode: 202, body: jobId }
+  return { statusCode: 202, body: job }
 }
 ```
 
@@ -394,10 +404,12 @@ exports.handler = async () => {
 ### Jobs — idempotency
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    body = event["body"] or {}
+    body = json.loads(event["body"] or "{}")
     # Same idempotency_key inside the window returns the existing job
     # id instead of enqueuing again. Useful for webhook handlers that
     # may be retried by the source.
@@ -543,7 +555,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "019df210-7b00-7e00-9c00-aab1cd2e3f44": "0 9 * * *",
+    "cron_expr": "0 9 * * *",
     "enabled":   true,
     "payload":   {"task": "daily-summary"}
   }'
@@ -551,7 +563,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
 
 ### Cron — Toggle / edit
 
-> PUT accepts any subset of {019df210-7b00-7e00-9c00-aab1cd2e3f44, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
+> PUT accepts any subset of {cron_expr, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
 
 ```bash
 # pause
@@ -564,7 +576,7 @@ curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9
 curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9c00-aab1cd2e3f44> \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
-  -d '{"019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/15 * * * *"}'
+  -d '{"cron_expr": "*/15 * * * *"}'
 ```
 
 ### Cron — List & delete
@@ -583,7 +595,7 @@ curl -X DELETE {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e0
 
 > **Cron-fired headers:** every cron-triggered invocation arrives at
 > the function with `x-orva-trigger: cron` and
-> `x-orva-cron-id: cron_…` on the event headers, so user code can
+> `x-orva-cron-id: <uuid>` on the event headers, so user code can
 > branch on origin.
 
 ---
@@ -1192,10 +1204,11 @@ might want to inspect it.
 Uses the scoped internal SDK endpoint and dispatches through the warm pool; the signed credential supplies immutable caller attribution while the named target may be another function. Recursion guard: max call depth 8. The callee's full {statusCode, headers, body} is returned; body is JSON-decoded when possible.
 
   Python:
+    import json
     from orva import invoke, OrvaError
 
     try:
-        res = invoke("resize-image", {"url": event["body"]["url"]})
+        res = invoke("resize-image", json.loads(event["body"] or "{}"))
         # res = {"statusCode": 200, "headers": {...}, "body": <decoded>}
     except OrvaError as e:
         # e.status: 404 = function not found, 408 = timeout,
@@ -1206,7 +1219,7 @@ Uses the scoped internal SDK endpoint and dispatches through the warm pool; the 
     const { invoke, OrvaError } = require('orva')
 
     try {
-      const res = await invoke('resize-image', { url: event.body.url })
+      const res = await invoke('resize-image', JSON.parse(event.body || '{}'))
     } catch (e) {
       if (e instanceof OrvaError) {
         return { statusCode: e.status || 502, body: { error: e.message } }
@@ -1219,36 +1232,36 @@ Fire-and-forget. Producer returns immediately; worker runs async on the same poo
 
   Python:
     from orva import jobs
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    job = jobs.enqueue(
         "send-welcome-email",
         {"to": "user@x.com", "tpl": "welcome"},
         max_attempts=3,                          # optional, default 3
         scheduled_at="2026-01-01T03:00:00Z",     # optional RFC3339; omit to run now
     )
-    # returns {"id": ..., "replayed": bool}
+    job_id = job["id"]    # returns {"id": ..., "replayed": bool}
 
   Node:
     const { jobs } = require('orva')
-    const jobId = await jobs.enqueue(
+    const { id: jobId } = await jobs.enqueue(   // returns { id, replayed }
       'send-welcome-email',
       { to: 'user@x.com', tpl: 'welcome' },
-      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // returns { id, replayed }
+      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // scheduledAt optional
     )
 
-The worker function receives the payload as event.body (parsed dict). Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "job_..." — branch on those when the same function handles both HTTP and queue work.
+The worker function receives the payload as event.body — a raw JSON string, like every other request, so parse it. Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "<uuid>" — branch on those when the same function handles both HTTP and queue work.
 
 Idempotency rule: jobs CAN run more than once on retry. Make worker handlers idempotent (check kv for a "done" marker keyed on payload, or use the job id).
 </orva_sdk>
 
 <schedules>
 Wire any function to a cron expression from the Schedules page or:
-  POST /api/v1/functions/<id>/cron   { "019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/5 * * * *", "timezone": "UTC", "enabled": true }
+  POST /api/v1/functions/<id>/cron   { "cron_expr": "*/5 * * * *", "timezone": "UTC", "enabled": true }
 
 Standard 5-field cron with shorthands: @hourly, @daily, @weekly, @monthly, @yearly. Plus the usual */N, ranges (1-5), and lists (1,15,30). Timezone defaults to the orvad process timezone; pass an IANA name to override per schedule.
 
 Cron-fired invocations arrive with these event headers — branch on them for dry-run / real-run logic, or to tag log lines:
   x-orva-trigger: "cron"
-  x-orva-cron-id: "cron_..."
+  x-orva-cron-id: "<uuid>"
 
 The scheduler is in-process (no external service), drift < 1s, survives restart, hot-reloads on edit. Failed cron runs emit a cron.failed webhook.
 </schedules>
@@ -1329,7 +1342,7 @@ There are no path parameters: the matched path arrives whole in event.path, so p
 Treat each handler as a tiny service. Apply these by default:
 
 1. Validate input early. Return 400 with {"error": "..."} for missing/typed-wrong fields. NEVER trust event.body without checking shape.
-2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, a request id (use event.headers["x-orva-request-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
+2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, the execution id (use event.headers["x-orva-execution-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
 3. Idempotency where it matters (POST / job workers / webhook receivers). Key on a client-supplied Idempotency-Key header or the job id; store a "done" marker in orva.kv with 24 h TTL.
 4. Timeouts on outbound HTTPS. httpx default is no timeout — set timeout=10. node fetch default is also no timeout — pass an AbortSignal.timeout(10_000). 30 s sandbox cap means you get killed mid-request otherwise.
 5. Catch broad, return narrow. try/except around your business logic; map to 400 / 401 / 404 / 502 / 500 with a short message. Don't leak stack traces in production responses (log them, return a request id).
@@ -1376,7 +1389,11 @@ async def handler(event):
         return {"statusCode": 405, "headers": {"Content-Type": "application/json"},
                 "body": {"error": "POST only"}}
 
-    body = event.get("body") or {}
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
+                "body": {"error": "invalid json"}}
     url = body.get("url") if isinstance(body, dict) else None
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
@@ -1442,7 +1459,7 @@ def handler(event):
         "msg": "session sweep done",
         "deleted": deleted,
         "trigger": "cron" if is_cron else "manual",
-        "request_id": event["headers"].get("x-orva-request-id"),
+        "execution_id": event["headers"].get("x-orva-execution-id"),
     }))
 
     return {"statusCode": 200,
@@ -1485,11 +1502,9 @@ exports.handler = async (event) => {
   if (event.method !== 'POST') {
     return { statusCode: 405, body: { error: 'POST only' } }
   }
-  // Stripe sends raw bytes. Orva passes the unparsed string through when
-  // Content-Type isn't application/json — make sure the route's content-type
-  // handling preserves the raw body. If event.body is an object (already
-  // parsed), JSON.stringify it back for verification.
-  const rawBody = typeof event.body === 'string' ? event.body : JSON.stringify(event.body)
+  // event.body is always the raw string Stripe sent, whatever the
+  // Content-Type, so the bytes the signature covers arrive intact.
+  const rawBody = event.body || ''
   const sigHeader = event.headers['stripe-signature']
   if (!verifyStripe(rawBody, sigHeader)) {
     return { statusCode: 401, body: { error: 'bad signature' } }
@@ -1497,7 +1512,7 @@ exports.handler = async (event) => {
 
   let payload
   try {
-    payload = typeof event.body === 'string' ? JSON.parse(event.body) : event.body
+    payload = JSON.parse(rawBody)
   } catch {
     return { statusCode: 400, body: { error: 'invalid json' } }
   }
@@ -1514,7 +1529,7 @@ exports.handler = async (event) => {
     level: 'info',
     msg: 'stripe webhook ok',
     type: payload.type,
-    request_id: event.headers['x-orva-request-id'],
+    execution_id: event.headers['x-orva-execution-id'],
   }))
 
   return { statusCode: 200, body: { received: true } }

--- a/backend/internal/mcp/tools_cron.go
+++ b/backend/internal/mcp/tools_cron.go
@@ -95,7 +95,7 @@ type CreateCronInput struct {
 }
 
 type UpdateCronInput struct {
-	ID       string         `json:"id"        jsonschema:"schedule id (cron_...)"`
+	ID       string         `json:"id"        jsonschema:"schedule id (UUIDv7, unprefixed)"`
 	CronExpr string         `json:"cron_expr,omitempty" jsonschema:"new cron expression; omit to keep"`
 	Enabled  *bool          `json:"enabled,omitempty"   jsonschema:"new enabled flag; omit to keep"`
 	Payload  map[string]any `json:"payload,omitempty"   jsonschema:"new payload; omit to keep"`

--- a/backend/internal/mcp/tools_jobs.go
+++ b/backend/internal/mcp/tools_jobs.go
@@ -86,7 +86,7 @@ type ListJobsOutput struct {
 }
 
 type JobIDInput struct {
-	ID string `json:"id" jsonschema:"job id (job_...)"`
+	ID string `json:"id" jsonschema:"job id (UUIDv7, unprefixed)"`
 }
 type JobIDInputWithConfirm struct {
 	ID      string `json:"id"`

--- a/cli/commands/reference.md
+++ b/cli/commands/reference.md
@@ -266,13 +266,17 @@ exports.handler = async (event) => {
 ### F2F — Python
 
 ```python
+import json
+
 from orva import invoke, OrvaError
 
 def handler(event):
+    # event["body"] is the raw request body, as a string. Always parse it.
+    url = json.loads(event["body"] or "{}")["url"]
     try:
         # invoke() returns the downstream {statusCode, headers, body}.
         # body is JSON-decoded when possible.
-        result = invoke("resize-image", {"url": event["body"]["url"]})
+        result = invoke("resize-image", {"url": url})
         return {"statusCode": 200, "body": result["body"]}
     except OrvaError as e:
         # 404 = function not found, 507 = call depth exceeded.
@@ -285,8 +289,10 @@ def handler(event):
 const { invoke, OrvaError } = require('orva')
 
 exports.handler = async (event) => {
+  // event.body is the raw request body, as a string. Always parse it.
+  const { url } = JSON.parse(event.body || '{}')
   try {
-    const result = await invoke('resize-image', { url: event.body.url })
+    const result = await invoke('resize-image', { url })
     return { statusCode: 200, body: result.body }
   } catch (e) {
     if (e instanceof OrvaError) {
@@ -302,18 +308,21 @@ exports.handler = async (event) => {
 ### Jobs — Python
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    # Fire-and-forget. Returns the job id immediately; the function
-    # body runs later via the scheduler. max_attempts retries with
+    # Fire-and-forget. Returns {"id": ..., "replayed": ...} immediately;
+    # the body runs later via the scheduler. max_attempts retries with
     # exponential backoff on 5xx / exception.
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    body = json.loads(event["body"] or "{}")
+    job = jobs.enqueue(
         "send-welcome-email",
-        {"to": event["body"]["email"]},
+        {"to": body["email"]},
         max_attempts=3,
     )
-    return {"statusCode": 202, "body": 019df210-7b00-7e00-9c00-aab1cd2e3f43}
+    return {"statusCode": 202, "body": job}
 ```
 
 ### Jobs — Node.js
@@ -322,12 +331,13 @@ def handler(event):
 const { jobs } = require('orva')
 
 exports.handler = async (event) => {
-  const jobId = await jobs.enqueue(
+  const { email } = JSON.parse(event.body || '{}')
+  const job = await jobs.enqueue(
     'send-welcome-email',
-    { to: event.body.email },
+    { to: email },
     { maxAttempts: 3 }
   )
-  return { statusCode: 202, body: jobId }
+  return { statusCode: 202, body: job }
 }
 ```
 
@@ -394,10 +404,12 @@ exports.handler = async () => {
 ### Jobs — idempotency
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    body = event["body"] or {}
+    body = json.loads(event["body"] or "{}")
     # Same idempotency_key inside the window returns the existing job
     # id instead of enqueuing again. Useful for webhook handlers that
     # may be retried by the source.
@@ -543,7 +555,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "019df210-7b00-7e00-9c00-aab1cd2e3f44": "0 9 * * *",
+    "cron_expr": "0 9 * * *",
     "enabled":   true,
     "payload":   {"task": "daily-summary"}
   }'
@@ -551,7 +563,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
 
 ### Cron — Toggle / edit
 
-> PUT accepts any subset of {019df210-7b00-7e00-9c00-aab1cd2e3f44, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
+> PUT accepts any subset of {cron_expr, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
 
 ```bash
 # pause
@@ -564,7 +576,7 @@ curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9
 curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9c00-aab1cd2e3f44> \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
-  -d '{"019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/15 * * * *"}'
+  -d '{"cron_expr": "*/15 * * * *"}'
 ```
 
 ### Cron — List & delete
@@ -583,7 +595,7 @@ curl -X DELETE {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e0
 
 > **Cron-fired headers:** every cron-triggered invocation arrives at
 > the function with `x-orva-trigger: cron` and
-> `x-orva-cron-id: cron_…` on the event headers, so user code can
+> `x-orva-cron-id: <uuid>` on the event headers, so user code can
 > branch on origin.
 
 ---
@@ -1192,10 +1204,11 @@ might want to inspect it.
 Uses the scoped internal SDK endpoint and dispatches through the warm pool; the signed credential supplies immutable caller attribution while the named target may be another function. Recursion guard: max call depth 8. The callee's full {statusCode, headers, body} is returned; body is JSON-decoded when possible.
 
   Python:
+    import json
     from orva import invoke, OrvaError
 
     try:
-        res = invoke("resize-image", {"url": event["body"]["url"]})
+        res = invoke("resize-image", json.loads(event["body"] or "{}"))
         # res = {"statusCode": 200, "headers": {...}, "body": <decoded>}
     except OrvaError as e:
         # e.status: 404 = function not found, 408 = timeout,
@@ -1206,7 +1219,7 @@ Uses the scoped internal SDK endpoint and dispatches through the warm pool; the 
     const { invoke, OrvaError } = require('orva')
 
     try {
-      const res = await invoke('resize-image', { url: event.body.url })
+      const res = await invoke('resize-image', JSON.parse(event.body || '{}'))
     } catch (e) {
       if (e instanceof OrvaError) {
         return { statusCode: e.status || 502, body: { error: e.message } }
@@ -1219,36 +1232,36 @@ Fire-and-forget. Producer returns immediately; worker runs async on the same poo
 
   Python:
     from orva import jobs
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    job = jobs.enqueue(
         "send-welcome-email",
         {"to": "user@x.com", "tpl": "welcome"},
         max_attempts=3,                          # optional, default 3
         scheduled_at="2026-01-01T03:00:00Z",     # optional RFC3339; omit to run now
     )
-    # returns {"id": ..., "replayed": bool}
+    job_id = job["id"]    # returns {"id": ..., "replayed": bool}
 
   Node:
     const { jobs } = require('orva')
-    const jobId = await jobs.enqueue(
+    const { id: jobId } = await jobs.enqueue(   // returns { id, replayed }
       'send-welcome-email',
       { to: 'user@x.com', tpl: 'welcome' },
-      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // returns { id, replayed }
+      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // scheduledAt optional
     )
 
-The worker function receives the payload as event.body (parsed dict). Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "job_..." — branch on those when the same function handles both HTTP and queue work.
+The worker function receives the payload as event.body — a raw JSON string, like every other request, so parse it. Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "<uuid>" — branch on those when the same function handles both HTTP and queue work.
 
 Idempotency rule: jobs CAN run more than once on retry. Make worker handlers idempotent (check kv for a "done" marker keyed on payload, or use the job id).
 </orva_sdk>
 
 <schedules>
 Wire any function to a cron expression from the Schedules page or:
-  POST /api/v1/functions/<id>/cron   { "019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/5 * * * *", "timezone": "UTC", "enabled": true }
+  POST /api/v1/functions/<id>/cron   { "cron_expr": "*/5 * * * *", "timezone": "UTC", "enabled": true }
 
 Standard 5-field cron with shorthands: @hourly, @daily, @weekly, @monthly, @yearly. Plus the usual */N, ranges (1-5), and lists (1,15,30). Timezone defaults to the orvad process timezone; pass an IANA name to override per schedule.
 
 Cron-fired invocations arrive with these event headers — branch on them for dry-run / real-run logic, or to tag log lines:
   x-orva-trigger: "cron"
-  x-orva-cron-id: "cron_..."
+  x-orva-cron-id: "<uuid>"
 
 The scheduler is in-process (no external service), drift < 1s, survives restart, hot-reloads on edit. Failed cron runs emit a cron.failed webhook.
 </schedules>
@@ -1329,7 +1342,7 @@ There are no path parameters: the matched path arrives whole in event.path, so p
 Treat each handler as a tiny service. Apply these by default:
 
 1. Validate input early. Return 400 with {"error": "..."} for missing/typed-wrong fields. NEVER trust event.body without checking shape.
-2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, a request id (use event.headers["x-orva-request-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
+2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, the execution id (use event.headers["x-orva-execution-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
 3. Idempotency where it matters (POST / job workers / webhook receivers). Key on a client-supplied Idempotency-Key header or the job id; store a "done" marker in orva.kv with 24 h TTL.
 4. Timeouts on outbound HTTPS. httpx default is no timeout — set timeout=10. node fetch default is also no timeout — pass an AbortSignal.timeout(10_000). 30 s sandbox cap means you get killed mid-request otherwise.
 5. Catch broad, return narrow. try/except around your business logic; map to 400 / 401 / 404 / 502 / 500 with a short message. Don't leak stack traces in production responses (log them, return a request id).
@@ -1376,7 +1389,11 @@ async def handler(event):
         return {"statusCode": 405, "headers": {"Content-Type": "application/json"},
                 "body": {"error": "POST only"}}
 
-    body = event.get("body") or {}
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
+                "body": {"error": "invalid json"}}
     url = body.get("url") if isinstance(body, dict) else None
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
@@ -1442,7 +1459,7 @@ def handler(event):
         "msg": "session sweep done",
         "deleted": deleted,
         "trigger": "cron" if is_cron else "manual",
-        "request_id": event["headers"].get("x-orva-request-id"),
+        "execution_id": event["headers"].get("x-orva-execution-id"),
     }))
 
     return {"statusCode": 200,
@@ -1485,11 +1502,9 @@ exports.handler = async (event) => {
   if (event.method !== 'POST') {
     return { statusCode: 405, body: { error: 'POST only' } }
   }
-  // Stripe sends raw bytes. Orva passes the unparsed string through when
-  // Content-Type isn't application/json — make sure the route's content-type
-  // handling preserves the raw body. If event.body is an object (already
-  // parsed), JSON.stringify it back for verification.
-  const rawBody = typeof event.body === 'string' ? event.body : JSON.stringify(event.body)
+  // event.body is always the raw string Stripe sent, whatever the
+  // Content-Type, so the bytes the signature covers arrive intact.
+  const rawBody = event.body || ''
   const sigHeader = event.headers['stripe-signature']
   if (!verifyStripe(rawBody, sigHeader)) {
     return { statusCode: 401, body: { error: 'bad signature' } }
@@ -1497,7 +1512,7 @@ exports.handler = async (event) => {
 
   let payload
   try {
-    payload = typeof event.body === 'string' ? JSON.parse(event.body) : event.body
+    payload = JSON.parse(rawBody)
   } catch {
     return { statusCode: 400, body: { error: 'invalid json' } }
   }
@@ -1514,7 +1529,7 @@ exports.handler = async (event) => {
     level: 'info',
     msg: 'stripe webhook ok',
     type: payload.type,
-    request_id: event.headers['x-orva-request-id'],
+    execution_id: event.headers['x-orva-execution-id'],
   }))
 
   return { statusCode: 200, body: { received: true } }

--- a/docs/RUNTIMES.md
+++ b/docs/RUNTIMES.md
@@ -40,8 +40,9 @@ single argument:
   should split `event["path"]` on `?` themselves.
 - Headers are normalized to lowercase keys.
 
-The Node adapter also passes `event.rawPath` and `event.httpMethod` aliases so
-AWS-Lambda-style handlers work without code changes. It accepts several handler
+Those five keys are the whole event — there are no `rawPath` / `httpMethod`
+aliases. What makes AWS-Lambda-style code run unchanged is the calling
+convention, not the key names: the Node adapter accepts several handler
 shapes besides the default: `handler(event, context)` (Lambda) and
 `handler(req, res)` (Vercel/Express). The Python adapter accepts a plain
 `handler(event)` and also speaks WSGI and ASGI, so Flask and FastAPI apps run
@@ -81,8 +82,8 @@ only Node's CommonJS resolver.
 
 ```js
 exports.handler = async (event) => {
-  const path   = event.path || event.rawPath || '/';
-  const method = event.method || event.httpMethod;
+  const path   = event.path || '/';
+  const method = event.method;
 
   if (method === 'GET' && path === '/health') {
     return { ok: true, ts: Date.now() };
@@ -113,8 +114,8 @@ return {
 
 ```python
 def handler(req):
-    method = req.get('method') or req.get('httpMethod')
-    path   = req.get('path')   or req.get('rawPath') or '/'
+    method = req.get('method')
+    path   = req.get('path') or '/'
 
     if method == 'GET' and path == '/health':
         return {'ok': True}

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -266,13 +266,17 @@ exports.handler = async (event) => {
 ### F2F — Python
 
 ```python
+import json
+
 from orva import invoke, OrvaError
 
 def handler(event):
+    # event["body"] is the raw request body, as a string. Always parse it.
+    url = json.loads(event["body"] or "{}")["url"]
     try:
         # invoke() returns the downstream {statusCode, headers, body}.
         # body is JSON-decoded when possible.
-        result = invoke("resize-image", {"url": event["body"]["url"]})
+        result = invoke("resize-image", {"url": url})
         return {"statusCode": 200, "body": result["body"]}
     except OrvaError as e:
         # 404 = function not found, 507 = call depth exceeded.
@@ -285,8 +289,10 @@ def handler(event):
 const { invoke, OrvaError } = require('orva')
 
 exports.handler = async (event) => {
+  // event.body is the raw request body, as a string. Always parse it.
+  const { url } = JSON.parse(event.body || '{}')
   try {
-    const result = await invoke('resize-image', { url: event.body.url })
+    const result = await invoke('resize-image', { url })
     return { statusCode: 200, body: result.body }
   } catch (e) {
     if (e instanceof OrvaError) {
@@ -302,18 +308,21 @@ exports.handler = async (event) => {
 ### Jobs — Python
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    # Fire-and-forget. Returns the job id immediately; the function
-    # body runs later via the scheduler. max_attempts retries with
+    # Fire-and-forget. Returns {"id": ..., "replayed": ...} immediately;
+    # the body runs later via the scheduler. max_attempts retries with
     # exponential backoff on 5xx / exception.
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    body = json.loads(event["body"] or "{}")
+    job = jobs.enqueue(
         "send-welcome-email",
-        {"to": event["body"]["email"]},
+        {"to": body["email"]},
         max_attempts=3,
     )
-    return {"statusCode": 202, "body": 019df210-7b00-7e00-9c00-aab1cd2e3f43}
+    return {"statusCode": 202, "body": job}
 ```
 
 ### Jobs — Node.js
@@ -322,12 +331,13 @@ def handler(event):
 const { jobs } = require('orva')
 
 exports.handler = async (event) => {
-  const jobId = await jobs.enqueue(
+  const { email } = JSON.parse(event.body || '{}')
+  const job = await jobs.enqueue(
     'send-welcome-email',
-    { to: event.body.email },
+    { to: email },
     { maxAttempts: 3 }
   )
-  return { statusCode: 202, body: jobId }
+  return { statusCode: 202, body: job }
 }
 ```
 
@@ -394,10 +404,12 @@ exports.handler = async () => {
 ### Jobs — idempotency
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    body = event["body"] or {}
+    body = json.loads(event["body"] or "{}")
     # Same idempotency_key inside the window returns the existing job
     # id instead of enqueuing again. Useful for webhook handlers that
     # may be retried by the source.
@@ -543,7 +555,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "019df210-7b00-7e00-9c00-aab1cd2e3f44": "0 9 * * *",
+    "cron_expr": "0 9 * * *",
     "enabled":   true,
     "payload":   {"task": "daily-summary"}
   }'
@@ -551,7 +563,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
 
 ### Cron — Toggle / edit
 
-> PUT accepts any subset of {019df210-7b00-7e00-9c00-aab1cd2e3f44, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
+> PUT accepts any subset of {cron_expr, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
 
 ```bash
 # pause
@@ -564,7 +576,7 @@ curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9
 curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9c00-aab1cd2e3f44> \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
-  -d '{"019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/15 * * * *"}'
+  -d '{"cron_expr": "*/15 * * * *"}'
 ```
 
 ### Cron — List & delete
@@ -583,7 +595,7 @@ curl -X DELETE {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e0
 
 > **Cron-fired headers:** every cron-triggered invocation arrives at
 > the function with `x-orva-trigger: cron` and
-> `x-orva-cron-id: cron_…` on the event headers, so user code can
+> `x-orva-cron-id: <uuid>` on the event headers, so user code can
 > branch on origin.
 
 ---
@@ -1192,10 +1204,11 @@ might want to inspect it.
 Uses the scoped internal SDK endpoint and dispatches through the warm pool; the signed credential supplies immutable caller attribution while the named target may be another function. Recursion guard: max call depth 8. The callee's full {statusCode, headers, body} is returned; body is JSON-decoded when possible.
 
   Python:
+    import json
     from orva import invoke, OrvaError
 
     try:
-        res = invoke("resize-image", {"url": event["body"]["url"]})
+        res = invoke("resize-image", json.loads(event["body"] or "{}"))
         # res = {"statusCode": 200, "headers": {...}, "body": <decoded>}
     except OrvaError as e:
         # e.status: 404 = function not found, 408 = timeout,
@@ -1206,7 +1219,7 @@ Uses the scoped internal SDK endpoint and dispatches through the warm pool; the 
     const { invoke, OrvaError } = require('orva')
 
     try {
-      const res = await invoke('resize-image', { url: event.body.url })
+      const res = await invoke('resize-image', JSON.parse(event.body || '{}'))
     } catch (e) {
       if (e instanceof OrvaError) {
         return { statusCode: e.status || 502, body: { error: e.message } }
@@ -1219,36 +1232,36 @@ Fire-and-forget. Producer returns immediately; worker runs async on the same poo
 
   Python:
     from orva import jobs
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    job = jobs.enqueue(
         "send-welcome-email",
         {"to": "user@x.com", "tpl": "welcome"},
         max_attempts=3,                          # optional, default 3
         scheduled_at="2026-01-01T03:00:00Z",     # optional RFC3339; omit to run now
     )
-    # returns {"id": ..., "replayed": bool}
+    job_id = job["id"]    # returns {"id": ..., "replayed": bool}
 
   Node:
     const { jobs } = require('orva')
-    const jobId = await jobs.enqueue(
+    const { id: jobId } = await jobs.enqueue(   // returns { id, replayed }
       'send-welcome-email',
       { to: 'user@x.com', tpl: 'welcome' },
-      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // returns { id, replayed }
+      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // scheduledAt optional
     )
 
-The worker function receives the payload as event.body (parsed dict). Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "job_..." — branch on those when the same function handles both HTTP and queue work.
+The worker function receives the payload as event.body — a raw JSON string, like every other request, so parse it. Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "<uuid>" — branch on those when the same function handles both HTTP and queue work.
 
 Idempotency rule: jobs CAN run more than once on retry. Make worker handlers idempotent (check kv for a "done" marker keyed on payload, or use the job id).
 </orva_sdk>
 
 <schedules>
 Wire any function to a cron expression from the Schedules page or:
-  POST /api/v1/functions/<id>/cron   { "019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/5 * * * *", "timezone": "UTC", "enabled": true }
+  POST /api/v1/functions/<id>/cron   { "cron_expr": "*/5 * * * *", "timezone": "UTC", "enabled": true }
 
 Standard 5-field cron with shorthands: @hourly, @daily, @weekly, @monthly, @yearly. Plus the usual */N, ranges (1-5), and lists (1,15,30). Timezone defaults to the orvad process timezone; pass an IANA name to override per schedule.
 
 Cron-fired invocations arrive with these event headers — branch on them for dry-run / real-run logic, or to tag log lines:
   x-orva-trigger: "cron"
-  x-orva-cron-id: "cron_..."
+  x-orva-cron-id: "<uuid>"
 
 The scheduler is in-process (no external service), drift < 1s, survives restart, hot-reloads on edit. Failed cron runs emit a cron.failed webhook.
 </schedules>
@@ -1329,7 +1342,7 @@ There are no path parameters: the matched path arrives whole in event.path, so p
 Treat each handler as a tiny service. Apply these by default:
 
 1. Validate input early. Return 400 with {"error": "..."} for missing/typed-wrong fields. NEVER trust event.body without checking shape.
-2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, a request id (use event.headers["x-orva-request-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
+2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, the execution id (use event.headers["x-orva-execution-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
 3. Idempotency where it matters (POST / job workers / webhook receivers). Key on a client-supplied Idempotency-Key header or the job id; store a "done" marker in orva.kv with 24 h TTL.
 4. Timeouts on outbound HTTPS. httpx default is no timeout — set timeout=10. node fetch default is also no timeout — pass an AbortSignal.timeout(10_000). 30 s sandbox cap means you get killed mid-request otherwise.
 5. Catch broad, return narrow. try/except around your business logic; map to 400 / 401 / 404 / 502 / 500 with a short message. Don't leak stack traces in production responses (log them, return a request id).
@@ -1376,7 +1389,11 @@ async def handler(event):
         return {"statusCode": 405, "headers": {"Content-Type": "application/json"},
                 "body": {"error": "POST only"}}
 
-    body = event.get("body") or {}
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
+                "body": {"error": "invalid json"}}
     url = body.get("url") if isinstance(body, dict) else None
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
@@ -1442,7 +1459,7 @@ def handler(event):
         "msg": "session sweep done",
         "deleted": deleted,
         "trigger": "cron" if is_cron else "manual",
-        "request_id": event["headers"].get("x-orva-request-id"),
+        "execution_id": event["headers"].get("x-orva-execution-id"),
     }))
 
     return {"statusCode": 200,
@@ -1485,11 +1502,9 @@ exports.handler = async (event) => {
   if (event.method !== 'POST') {
     return { statusCode: 405, body: { error: 'POST only' } }
   }
-  // Stripe sends raw bytes. Orva passes the unparsed string through when
-  // Content-Type isn't application/json — make sure the route's content-type
-  // handling preserves the raw body. If event.body is an object (already
-  // parsed), JSON.stringify it back for verification.
-  const rawBody = typeof event.body === 'string' ? event.body : JSON.stringify(event.body)
+  // event.body is always the raw string Stripe sent, whatever the
+  // Content-Type, so the bytes the signature covers arrive intact.
+  const rawBody = event.body || ''
   const sigHeader = event.headers['stripe-signature']
   if (!verifyStripe(rawBody, sigHeader)) {
     return { statusCode: 401, body: { error: 'bad signature' } }
@@ -1497,7 +1512,7 @@ exports.handler = async (event) => {
 
   let payload
   try {
-    payload = typeof event.body === 'string' ? JSON.parse(event.body) : event.body
+    payload = JSON.parse(rawBody)
   } catch {
     return { statusCode: 400, body: { error: 'invalid json' } }
   }
@@ -1514,7 +1529,7 @@ exports.handler = async (event) => {
     level: 'info',
     msg: 'stripe webhook ok',
     type: payload.type,
-    request_id: event.headers['x-orva-request-id'],
+    execution_id: event.headers['x-orva-execution-id'],
   }))
 
   return { statusCode: 200, body: { received: true } }

--- a/frontend/public/docs.md
+++ b/frontend/public/docs.md
@@ -266,13 +266,17 @@ exports.handler = async (event) => {
 ### F2F — Python
 
 ```python
+import json
+
 from orva import invoke, OrvaError
 
 def handler(event):
+    # event["body"] is the raw request body, as a string. Always parse it.
+    url = json.loads(event["body"] or "{}")["url"]
     try:
         # invoke() returns the downstream {statusCode, headers, body}.
         # body is JSON-decoded when possible.
-        result = invoke("resize-image", {"url": event["body"]["url"]})
+        result = invoke("resize-image", {"url": url})
         return {"statusCode": 200, "body": result["body"]}
     except OrvaError as e:
         # 404 = function not found, 507 = call depth exceeded.
@@ -285,8 +289,10 @@ def handler(event):
 const { invoke, OrvaError } = require('orva')
 
 exports.handler = async (event) => {
+  // event.body is the raw request body, as a string. Always parse it.
+  const { url } = JSON.parse(event.body || '{}')
   try {
-    const result = await invoke('resize-image', { url: event.body.url })
+    const result = await invoke('resize-image', { url })
     return { statusCode: 200, body: result.body }
   } catch (e) {
     if (e instanceof OrvaError) {
@@ -302,18 +308,21 @@ exports.handler = async (event) => {
 ### Jobs — Python
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    # Fire-and-forget. Returns the job id immediately; the function
-    # body runs later via the scheduler. max_attempts retries with
+    # Fire-and-forget. Returns {"id": ..., "replayed": ...} immediately;
+    # the body runs later via the scheduler. max_attempts retries with
     # exponential backoff on 5xx / exception.
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    body = json.loads(event["body"] or "{}")
+    job = jobs.enqueue(
         "send-welcome-email",
-        {"to": event["body"]["email"]},
+        {"to": body["email"]},
         max_attempts=3,
     )
-    return {"statusCode": 202, "body": 019df210-7b00-7e00-9c00-aab1cd2e3f43}
+    return {"statusCode": 202, "body": job}
 ```
 
 ### Jobs — Node.js
@@ -322,12 +331,13 @@ def handler(event):
 const { jobs } = require('orva')
 
 exports.handler = async (event) => {
-  const jobId = await jobs.enqueue(
+  const { email } = JSON.parse(event.body || '{}')
+  const job = await jobs.enqueue(
     'send-welcome-email',
-    { to: event.body.email },
+    { to: email },
     { maxAttempts: 3 }
   )
-  return { statusCode: 202, body: jobId }
+  return { statusCode: 202, body: job }
 }
 ```
 
@@ -394,10 +404,12 @@ exports.handler = async () => {
 ### Jobs — idempotency
 
 ```python
+import json
+
 from orva import jobs
 
 def handler(event):
-    body = event["body"] or {}
+    body = json.loads(event["body"] or "{}")
     # Same idempotency_key inside the window returns the existing job
     # id instead of enqueuing again. Useful for webhook handlers that
     # may be retried by the source.
@@ -543,7 +555,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
   -d '{
-    "019df210-7b00-7e00-9c00-aab1cd2e3f44": "0 9 * * *",
+    "cron_expr": "0 9 * * *",
     "enabled":   true,
     "payload":   {"task": "daily-summary"}
   }'
@@ -551,7 +563,7 @@ curl -X POST {{ORIGIN}}/api/v1/functions/<function_id>/cron \
 
 ### Cron — Toggle / edit
 
-> PUT accepts any subset of {019df210-7b00-7e00-9c00-aab1cd2e3f44, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
+> PUT accepts any subset of {cron_expr, enabled, payload}; omitted fields keep their previous value. next_run_at is recomputed on expr changes.
 
 ```bash
 # pause
@@ -564,7 +576,7 @@ curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9
 curl -X PUT {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e00-9c00-aab1cd2e3f44> \
   -H 'X-Orva-API-Key: <YOUR_KEY>' \
   -H 'Content-Type: application/json' \
-  -d '{"019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/15 * * * *"}'
+  -d '{"cron_expr": "*/15 * * * *"}'
 ```
 
 ### Cron — List & delete
@@ -583,7 +595,7 @@ curl -X DELETE {{ORIGIN}}/api/v1/functions/<function_id>/cron/<019df210-7b00-7e0
 
 > **Cron-fired headers:** every cron-triggered invocation arrives at
 > the function with `x-orva-trigger: cron` and
-> `x-orva-cron-id: cron_…` on the event headers, so user code can
+> `x-orva-cron-id: <uuid>` on the event headers, so user code can
 > branch on origin.
 
 ---
@@ -1192,10 +1204,11 @@ might want to inspect it.
 Uses the scoped internal SDK endpoint and dispatches through the warm pool; the signed credential supplies immutable caller attribution while the named target may be another function. Recursion guard: max call depth 8. The callee's full {statusCode, headers, body} is returned; body is JSON-decoded when possible.
 
   Python:
+    import json
     from orva import invoke, OrvaError
 
     try:
-        res = invoke("resize-image", {"url": event["body"]["url"]})
+        res = invoke("resize-image", json.loads(event["body"] or "{}"))
         # res = {"statusCode": 200, "headers": {...}, "body": <decoded>}
     except OrvaError as e:
         # e.status: 404 = function not found, 408 = timeout,
@@ -1206,7 +1219,7 @@ Uses the scoped internal SDK endpoint and dispatches through the warm pool; the 
     const { invoke, OrvaError } = require('orva')
 
     try {
-      const res = await invoke('resize-image', { url: event.body.url })
+      const res = await invoke('resize-image', JSON.parse(event.body || '{}'))
     } catch (e) {
       if (e instanceof OrvaError) {
         return { statusCode: e.status || 502, body: { error: e.message } }
@@ -1219,36 +1232,36 @@ Fire-and-forget. Producer returns immediately; worker runs async on the same poo
 
   Python:
     from orva import jobs
-    019df210-7b00-7e00-9c00-aab1cd2e3f43 = jobs.enqueue(
+    job = jobs.enqueue(
         "send-welcome-email",
         {"to": "user@x.com", "tpl": "welcome"},
         max_attempts=3,                          # optional, default 3
         scheduled_at="2026-01-01T03:00:00Z",     # optional RFC3339; omit to run now
     )
-    # returns {"id": ..., "replayed": bool}
+    job_id = job["id"]    # returns {"id": ..., "replayed": bool}
 
   Node:
     const { jobs } = require('orva')
-    const jobId = await jobs.enqueue(
+    const { id: jobId } = await jobs.enqueue(   // returns { id, replayed }
       'send-welcome-email',
       { to: 'user@x.com', tpl: 'welcome' },
-      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // returns { id, replayed }
+      { maxAttempts: 3, scheduledAt: '2026-01-01T03:00:00Z' }   // scheduledAt optional
     )
 
-The worker function receives the payload as event.body (parsed dict). Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "job_..." — branch on those when the same function handles both HTTP and queue work.
+The worker function receives the payload as event.body — a raw JSON string, like every other request, so parse it. Job-fired invocations arrive with header x-orva-trigger: "job" and x-orva-job-id: "<uuid>" — branch on those when the same function handles both HTTP and queue work.
 
 Idempotency rule: jobs CAN run more than once on retry. Make worker handlers idempotent (check kv for a "done" marker keyed on payload, or use the job id).
 </orva_sdk>
 
 <schedules>
 Wire any function to a cron expression from the Schedules page or:
-  POST /api/v1/functions/<id>/cron   { "019df210-7b00-7e00-9c00-aab1cd2e3f44": "*/5 * * * *", "timezone": "UTC", "enabled": true }
+  POST /api/v1/functions/<id>/cron   { "cron_expr": "*/5 * * * *", "timezone": "UTC", "enabled": true }
 
 Standard 5-field cron with shorthands: @hourly, @daily, @weekly, @monthly, @yearly. Plus the usual */N, ranges (1-5), and lists (1,15,30). Timezone defaults to the orvad process timezone; pass an IANA name to override per schedule.
 
 Cron-fired invocations arrive with these event headers — branch on them for dry-run / real-run logic, or to tag log lines:
   x-orva-trigger: "cron"
-  x-orva-cron-id: "cron_..."
+  x-orva-cron-id: "<uuid>"
 
 The scheduler is in-process (no external service), drift < 1s, survives restart, hot-reloads on edit. Failed cron runs emit a cron.failed webhook.
 </schedules>
@@ -1329,7 +1342,7 @@ There are no path parameters: the matched path arrives whole in event.path, so p
 Treat each handler as a tiny service. Apply these by default:
 
 1. Validate input early. Return 400 with {"error": "..."} for missing/typed-wrong fields. NEVER trust event.body without checking shape.
-2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, a request id (use event.headers["x-orva-request-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
+2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, the execution id (use event.headers["x-orva-execution-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
 3. Idempotency where it matters (POST / job workers / webhook receivers). Key on a client-supplied Idempotency-Key header or the job id; store a "done" marker in orva.kv with 24 h TTL.
 4. Timeouts on outbound HTTPS. httpx default is no timeout — set timeout=10. node fetch default is also no timeout — pass an AbortSignal.timeout(10_000). 30 s sandbox cap means you get killed mid-request otherwise.
 5. Catch broad, return narrow. try/except around your business logic; map to 400 / 401 / 404 / 502 / 500 with a short message. Don't leak stack traces in production responses (log them, return a request id).
@@ -1376,7 +1389,11 @@ async def handler(event):
         return {"statusCode": 405, "headers": {"Content-Type": "application/json"},
                 "body": {"error": "POST only"}}
 
-    body = event.get("body") or {}
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
+                "body": {"error": "invalid json"}}
     url = body.get("url") if isinstance(body, dict) else None
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
@@ -1442,7 +1459,7 @@ def handler(event):
         "msg": "session sweep done",
         "deleted": deleted,
         "trigger": "cron" if is_cron else "manual",
-        "request_id": event["headers"].get("x-orva-request-id"),
+        "execution_id": event["headers"].get("x-orva-execution-id"),
     }))
 
     return {"statusCode": 200,
@@ -1485,11 +1502,9 @@ exports.handler = async (event) => {
   if (event.method !== 'POST') {
     return { statusCode: 405, body: { error: 'POST only' } }
   }
-  // Stripe sends raw bytes. Orva passes the unparsed string through when
-  // Content-Type isn't application/json — make sure the route's content-type
-  // handling preserves the raw body. If event.body is an object (already
-  // parsed), JSON.stringify it back for verification.
-  const rawBody = typeof event.body === 'string' ? event.body : JSON.stringify(event.body)
+  // event.body is always the raw string Stripe sent, whatever the
+  // Content-Type, so the bytes the signature covers arrive intact.
+  const rawBody = event.body || ''
   const sigHeader = event.headers['stripe-signature']
   if (!verifyStripe(rawBody, sigHeader)) {
     return { statusCode: 401, body: { error: 'bad signature' } }
@@ -1497,7 +1512,7 @@ exports.handler = async (event) => {
 
   let payload
   try {
-    payload = typeof event.body === 'string' ? JSON.parse(event.body) : event.body
+    payload = JSON.parse(rawBody)
   } catch {
     return { statusCode: 400, body: { error: 'invalid json' } }
   }
@@ -1514,7 +1529,7 @@ exports.handler = async (event) => {
     level: 'info',
     msg: 'stripe webhook ok',
     type: payload.type,
-    request_id: event.headers['x-orva-request-id'],
+    execution_id: event.headers['x-orva-execution-id'],
   }))
 
   return { statusCode: 200, body: { received: true } }

--- a/frontend/src/utils/aiPrompts.js
+++ b/frontend/src/utils/aiPrompts.js
@@ -109,10 +109,11 @@ might want to inspect it.
 Uses the scoped internal SDK endpoint and dispatches through the warm pool; the signed credential supplies immutable caller attribution while the named target may be another function. Recursion guard: max call depth 8. The callee's full {statusCode, headers, body} is returned; body is JSON-decoded when possible.
 
   Python:
+    import json
     from orva import invoke, OrvaError
 
     try:
-        res = invoke("resize-image", {"url": event["body"]["url"]})
+        res = invoke("resize-image", json.loads(event["body"] or "{}"))
         # res = {"statusCode": 200, "headers": {...}, "body": <decoded>}
     except OrvaError as e:
         # e.status: 404 = function not found, 408 = timeout,
@@ -123,7 +124,7 @@ Uses the scoped internal SDK endpoint and dispatches through the warm pool; the 
     const { invoke, OrvaError } = require('orva')
 
     try {
-      const res = await invoke('resize-image', { url: event.body.url })
+      const res = await invoke('resize-image', JSON.parse(event.body || '{}'))
     } catch (e) {
       if (e instanceof OrvaError) {
         return { statusCode: e.status || 502, body: { error: e.message } }
@@ -258,7 +259,7 @@ Channels do not change how you write the handler. The HTTP request the channel-t
 Treat each handler as a tiny service. Apply these by default:
 
 1. Validate input early. Return 400 with {"error": "..."} for missing/typed-wrong fields. NEVER trust event.body without checking shape.
-2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, a request id (use event.headers["x-orva-request-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
+2. Structured logs. print(json.dumps({...})) in Python or console.log(JSON.stringify({...})) in Node — one JSON object per line, includes a level, the execution id (use event.headers["x-orva-execution-id"]), and any relevant ids. Logs land on the Activity page and on stdout.
 3. Idempotency where it matters (POST / job workers / webhook receivers). Key on a client-supplied Idempotency-Key header or the job id; store a "done" marker in orva.kv with 24 h TTL.
 4. Timeouts on outbound HTTPS. httpx default is no timeout — set timeout=10. node fetch default is also no timeout — pass an AbortSignal.timeout(10_000). 30 s sandbox cap means you get killed mid-request otherwise.
 5. Catch broad, return narrow. try/except around your business logic; map to 400 / 401 / 404 / 502 / 500 with a short message. Don't leak stack traces in production responses (log them, return a request id).
@@ -305,7 +306,11 @@ async def handler(event):
         return {"statusCode": 405, "headers": {"Content-Type": "application/json"},
                 "body": {"error": "POST only"}}
 
-    body = event.get("body") or {}
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError:
+        return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
+                "body": {"error": "invalid json"}}
     url = body.get("url") if isinstance(body, dict) else None
     if not isinstance(url, str) or not url.startswith(("http://", "https://")):
         return {"statusCode": 400, "headers": {"Content-Type": "application/json"},
@@ -371,7 +376,7 @@ def handler(event):
         "msg": "session sweep done",
         "deleted": deleted,
         "trigger": "cron" if is_cron else "manual",
-        "request_id": event["headers"].get("x-orva-request-id"),
+        "execution_id": event["headers"].get("x-orva-execution-id"),
     }))
 
     return {"statusCode": 200,
@@ -414,11 +419,9 @@ exports.handler = async (event) => {
   if (event.method !== 'POST') {
     return { statusCode: 405, body: { error: 'POST only' } }
   }
-  // Stripe sends raw bytes. Orva passes the unparsed string through when
-  // Content-Type isn't application/json — make sure the route's content-type
-  // handling preserves the raw body. If event.body is an object (already
-  // parsed), JSON.stringify it back for verification.
-  const rawBody = typeof event.body === 'string' ? event.body : JSON.stringify(event.body)
+  // event.body is always the raw string Stripe sent, whatever the
+  // Content-Type, so the bytes the signature covers arrive intact.
+  const rawBody = event.body || ''
   const sigHeader = event.headers['stripe-signature']
   if (!verifyStripe(rawBody, sigHeader)) {
     return { statusCode: 401, body: { error: 'bad signature' } }
@@ -426,7 +429,7 @@ exports.handler = async (event) => {
 
   let payload
   try {
-    payload = typeof event.body === 'string' ? JSON.parse(event.body) : event.body
+    payload = JSON.parse(rawBody)
   } catch {
     return { statusCode: 400, body: { error: 'invalid json' } }
   }
@@ -443,7 +446,7 @@ exports.handler = async (event) => {
     level: 'info',
     msg: 'stripe webhook ok',
     type: payload.type,
-    request_id: event.headers['x-orva-request-id'],
+    execution_id: event.headers['x-orva-execution-id'],
   }))
 
   return { statusCode: 200, body: { received: true } }

--- a/frontend/src/views/Docs.vue
+++ b/frontend/src/views/Docs.vue
@@ -469,7 +469,7 @@
         Every cron-triggered invocation arrives at the function with
         <code class="doc-chip">x-orva-trigger: cron</code>
         and
-        <code class="doc-chip">x-orva-cron-id: cron_…</code>
+        <code class="doc-chip">x-orva-cron-id: &lt;uuid&gt;</code>
         on the event headers, so user code can branch on origin.
       </Callout>
     </section>
@@ -1688,13 +1688,17 @@ const sdkInvokeTabs = [
   {
     label: 'Python',
     lang: 'python',
-    code: `from orva import invoke, OrvaError
+    code: `import json
+
+from orva import invoke, OrvaError
 
 def handler(event):
+    # event["body"] is the raw request body, as a string. Always parse it.
+    url = json.loads(event["body"] or "{}")["url"]
     try:
         # invoke() returns the downstream {statusCode, headers, body}.
         # body is JSON-decoded when possible.
-        result = invoke("resize-image", {"url": event["body"]["url"]})
+        result = invoke("resize-image", {"url": url})
         return {"statusCode": 200, "body": result["body"]}
     except OrvaError as e:
         # 404 = function not found, 507 = call depth exceeded.
@@ -1724,18 +1728,21 @@ const sdkJobsTabs = [
   {
     label: 'Python',
     lang: 'python',
-    code: `from orva import jobs
+    code: `import json
+
+from orva import jobs
 
 def handler(event):
-    # Fire-and-forget. Returns the job id immediately; the function
-    # body runs later via the scheduler. max_attempts retries with
+    # Fire-and-forget. Returns {"id": ..., "replayed": ...} immediately;
+    # the body runs later via the scheduler. max_attempts retries with
     # exponential backoff on 5xx / exception.
-    job_id = jobs.enqueue(
+    body = json.loads(event["body"] or "{}")
+    job = jobs.enqueue(
         "send-welcome-email",
-        {"to": event["body"]["email"]},
+        {"to": body["email"]},
         max_attempts=3,
     )
-    return {"statusCode": 202, "body": job_id}`,
+    return {"statusCode": 202, "body": job}`,
   },
   {
     label: 'Node.js',
@@ -1743,12 +1750,13 @@ def handler(event):
     code: `const { jobs } = require('orva')
 
 exports.handler = async (event) => {
-  const jobId = await jobs.enqueue(
+  const { email } = JSON.parse(event.body || '{}')
+  const job = await jobs.enqueue(
     'send-welcome-email',
-    { to: JSON.parse(event.body || '{}').email },
+    { to: email },
     { maxAttempts: 3 }
   )
-  return { statusCode: 202, body: jobId }
+  return { statusCode: 202, body: job }
 }`,
   },
 ]

--- a/frontend/src/views/Editor.vue
+++ b/frontend/src/views/Editor.vue
@@ -1212,7 +1212,7 @@
         </p>
         <pre class="bg-surface border border-border rounded p-3 font-mono text-[12px] text-foreground-strong overflow-x-auto scrollable whitespace-pre">{{ handlerHint }}</pre>
         <ul class="space-y-1 pl-4 list-disc marker:text-foreground-muted">
-          <li><span class="text-foreground-strong font-mono">event.body</span> is the raw request body (string or parsed JSON).</li>
+          <li><span class="text-foreground-strong font-mono">event.body</span> is the raw request body, always a string. Parse it yourself.</li>
           <li>Return <span class="text-foreground-strong font-mono">{ statusCode, headers, body }</span>.</li>
           <li>Add packages via the <span class="text-foreground-strong">Deps</span> panel (installed at build time).</li>
         </ul>


### PR DESCRIPTION
Six wrong examples, in the four places a function author actually reads. PR 5 of the bug-hunt cleanup.

`CONTRACT.md`'s preamble records a 2026-08-25 audit that found 181 doc defects, 81 factually wrong — *including a handler contract whose two headline examples produced an HTTP 500 and a silently wrong answer*. These are more of the same, found afterwards.

## What was broken

| Where | Defect |
|---|---|
| `reference.md:546` | the cron API example named its request field with a **UUID** instead of `cron_expr` — the documented `curl` **always returned 400** |
| `reference.md:311` | the Python `jobs.enqueue` example used a UUID as a variable name: a literal **`SyntaxError`** |
| `reference.md:275` | F2F and jobs examples indexed `event.body` as if the platform parsed it — **Python 500s, Node silently sends an empty payload** |
| `aiPrompts.js:308` | the flagship multi-shot example rejected every valid request with 400 |
| `aiPrompts.js:261` | told the assistant to log `x-orva-request-id` — **zero hits** for that header anywhere in the tree |
| `RUNTIMES.md:43` | promised `event.rawPath` / `event.httpMethod` aliases **neither adapter has ever provided** |

Reproduced before and after against the **real adapters** over their framed stdio protocol:

```
F2F python   500 {"error":"Internal function error"}  ->  200 {"echoed":{"url":"https://x.test/a.png"}}
F2F node     200 {"echoed":{}}                        ->  200 {"echoed":{"url":"https://x.test/a.png"}}
jobs python  SyntaxError: leading zeros...            ->  202 {"echoed":{"to":"a@b.test"}}
```

The Node F2F case is the dangerous one: it returned **200 with an empty payload**. No error, no signal, just a silently wrong answer.

## Two things the review caught

**The half-fix.** `Editor.vue:1215` — the Handler reference modal a function author opens *while writing the handler* — still said `event.body` is "the raw request body (string or parsed JSON)". That's the highest-traffic statement of the contract in the entire product, and it was about to be the lone contradicting sentence left in the tree.

**A new 500 in the fix itself.** The first cut rewrote an `orva.invoke` fragment to use `json.loads` without adding `import json`, in a snippet that declares its own imports — trading one 500-ing Python example for a different one, *inside the file this change calls "documentation that executes"*. Fixed in all five copies, then re-scanned: no fenced example uses `json` without importing it.

## Also

`RUNTIMES.md`'s alias promise is **removed rather than the aliases added** — the event shape is a contract, and `proxy.go:270` sends exactly `{Method, Path, Headers, Body}`.

Two MCP tool schemas claimed job and schedule ids arrive prefixed `job_` / `cron_`. `NewJobID()` and `NewCronID()` are both `ids.New()` — bare UUIDv7 — and that description ships into every connected agent's tool schema.

## Verification

`go build` OK, `go vet` clean, 25 packages green, eslint clean, 53 frontend tests pass, `node --check` on `aiPrompts.js`, and all three `reference.md` mirrors byte-identical after `make docs-embed`.
