### PR TITLE
Fix the builder log race, a dangling migration pointer, and three installer papercuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,29 @@ before it.
   Two MCP tool schemas claimed job and schedule ids arrive prefixed `job_` /
   `cron_`; both are bare UUIDv7s, and that description ships to every connected
   agent.
+- **Concurrent builds wrote into each other's logs.** The build queue runs one
+  worker per CPU and they all shared a single builder, each setting its log
+  writer on that shared object and clearing it in a defer. So a build streamed
+  its `pip`/`npm` output into another deployment's log, and the first build to
+  finish cleared the writer out from under every build still running, which
+  simply lost the rest. It is a data race, not only a mix-up — the race
+  detector reports it. Each job now builds through its own copy.
+
+- **The UUIDv7 id migration left `functions.active_deployment_id` dangling.**
+  That column holds a deployment id but was added by `ALTER` with no foreign
+  key, so the migration's automatic child discovery could not see it and it was
+  missing from the hand-maintained list of unreferenced columns. Deployment ids
+  were rewritten and the pointer was not, leaving it aimed at an id that no
+  longer existed. The existing backfill could never repair it, because it only
+  fills the column when it is empty.
+
+- **Three installer papercuts.** `install.sh --help` printed its own `curl`
+  one-liner with the URL missing, because `--help` exits before that URL is
+  derived. The "already at this version, nothing to do" check could never be
+  true: it compared `orva --version`'s output, `orva vX.Y.Z`, against `vX.Y.Z`.
+  And `install-cli.ps1`'s "checksum entry missing" error deleted the checksums
+  file immediately before quoting its first five lines, so the one diagnostic
+  that would tell you what went wrong was always blank.
 
 - **On Alpine, a successful `orva backup restore` left the server down
   permanently.** `orva backup restore` exits 70 on purpose so its supervisor

--- a/backend/internal/builder/builder.go
+++ b/backend/internal/builder/builder.go
@@ -68,7 +68,8 @@ type Builder struct {
 
 	// Logger, when non-nil, receives per-line stdout/stderr from pip/npm
 	// and validator output so build progress can stream into build_logs.
-	// Set by the Queue worker right before calling Build and cleared after.
+	// Set on a per-job COPY of the Builder -- never on a shared one, or
+	// concurrent workers cross-attribute their output.
 	Logger interface {
 		Append(stream, line string)
 	}

--- a/backend/internal/builder/queue.go
+++ b/backend/internal/builder/queue.go
@@ -177,11 +177,14 @@ func (q *Queue) runJob(workerID int, job BuildJob) {
 	}
 
 	lw := newLogWriter(q.db, job.DeploymentID)
-	q.bld.Logger = lw
-	defer func() { q.bld.Logger = nil }()
+	// Per-job copy: Logger used to be set on the one shared *Builder, so with
+	// NumCPU workers a build wrote its output to another job's log and the
+	// first defer to fire nil'd the logger out from under the rest.
+	bld := *q.bld
+	bld.Logger = lw
 
 	_ = q.db.UpdateDeploymentPhase(job.DeploymentID, "deps")
-	result, buildErr := q.bld.Build(context.Background(), fn, job.TarballPath)
+	result, buildErr := bld.Build(context.Background(), fn, job.TarballPath)
 
 	if buildErr != nil {
 		logger.Warn("build failed", "err", buildErr)

--- a/backend/internal/builder/queue_logger_race_test.go
+++ b/backend/internal/builder/queue_logger_race_test.go
@@ -1,0 +1,61 @@
+package builder
+
+import (
+	"sync"
+	"testing"
+)
+
+// capturingLogger records which job's logger received which line.
+type capturingLogger struct {
+	mu    sync.Mutex
+	job   string
+	lines []string
+}
+
+func (c *capturingLogger) Append(stream, line string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, line)
+}
+
+// TestConcurrentBuildsDoNotShareTheLogger pins the fix for the shared-*Builder
+// race: Logger used to be set on the queue's single *Builder, so concurrent
+// workers cross-attributed output and the first defer to fire nil'd the logger
+// out from under every build still running.
+//
+// Run with -race: writing Logger on a shared Builder while another goroutine's
+// Build reads it is a data race, not merely a mix-up.
+func TestConcurrentBuildsDoNotShareTheLogger(t *testing.T) {
+	shared := &Builder{DataDir: t.TempDir()}
+
+	const n = 8
+	var wg sync.WaitGroup
+	loggers := make([]*capturingLogger, n)
+	release := make(chan struct{})
+
+	for i := 0; i < n; i++ {
+		loggers[i] = &capturingLogger{job: string(rune('a' + i))}
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			// Exactly what the queue worker does now: copy, then set.
+			bld := *shared
+			bld.Logger = loggers[i]
+			<-release // maximise overlap
+			// logLines is the real consumer of b.Logger.
+			logLines(&bld, "stdout", []byte(loggers[i].job))
+		}(i)
+	}
+	close(release)
+	wg.Wait()
+
+	// Every logger must have received its own line and nothing else.
+	for i, l := range loggers {
+		if len(l.lines) != 1 || l.lines[0] != l.job {
+			t.Errorf("logger %d got %v, want exactly [%q]", i, l.lines, l.job)
+		}
+	}
+	if shared.Logger != nil {
+		t.Errorf("the shared Builder was mutated: Logger = %v", shared.Logger)
+	}
+}

--- a/backend/internal/database/migrate_to_uuidv7.go
+++ b/backend/internal/database/migrate_to_uuidv7.go
@@ -80,6 +80,10 @@ var rewrites = []idRewrite{
 		parentTable: "deployments", idColumn: "id",
 		softRefs: []childRef{
 			{"deployments", "parent_deployment_id"}, // self-reference
+			// Added by ALTER with no FK, so foreign_key_list cannot see it.
+			// Left out, it kept the pre-migration dep_ id forever:
+			// backfillActiveDeployment only fills '' and never repairs a dangle.
+			{"functions", "active_deployment_id"},
 		},
 	},
 	{

--- a/backend/internal/database/migrate_to_uuidv7_coverage_test.go
+++ b/backend/internal/database/migrate_to_uuidv7_coverage_test.go
@@ -261,6 +261,41 @@ func TestMigrationRewritesSoftReferences(t *testing.T) {
 	assertCount(t, db, `SELECT COUNT(*) FROM jobs WHERE enqueued_by_function_id = ?`, 0, legacyParentFnID)
 }
 
+// TestMigrationRewritesActiveDeploymentID pins the one soft reference the
+// rewrite used to miss. functions.active_deployment_id is added by ALTER with
+// no FK, so PRAGMA foreign_key_list cannot see it, and it was absent from the
+// deployments soft-ref list -- so it kept its pre-migration dep_ id forever.
+// backfillActiveDeployment cannot repair that: it only fills '' values.
+//
+// Fails on the pre-fix code: the column still holds the legacy id.
+func TestMigrationRewritesActiveDeploymentID(t *testing.T) {
+	db, _ := unmigratedDB(t)
+
+	const legacyFnID = "fn_activedep0001"
+	const legacyDepID = "dep_activedep001"
+
+	mustExecT(t, db, `INSERT INTO functions (id, name, runtime, entrypoint, active_deployment_id) VALUES (?, ?, ?, ?, ?)`,
+		legacyFnID, "active-dep-func", "python", "handler.py", legacyDepID)
+	mustExecT(t, db, `INSERT INTO deployments (id, function_id, version, status, submitted_at) VALUES (?, ?, 1, 'succeeded', datetime('now'))`,
+		legacyDepID, legacyFnID)
+
+	assertCount(t, db, `SELECT COUNT(*) FROM functions WHERE active_deployment_id = ?`, 1, legacyDepID)
+
+	if err := db.MigrateToUUIDv7(); err != nil {
+		t.Fatalf("migration failed: %v", err)
+	}
+
+	var newDepID string
+	if err := db.read.QueryRow(`SELECT id FROM deployments`).Scan(&newDepID); err != nil {
+		t.Fatal(err)
+	}
+
+	// It must point at the rewritten deployment, and nothing may still hold
+	// the legacy value -- a dangling pointer here silently breaks rollback.
+	assertCount(t, db, `SELECT COUNT(*) FROM functions WHERE active_deployment_id = ?`, 1, newDepID)
+	assertCount(t, db, `SELECT COUNT(*) FROM functions WHERE active_deployment_id = ?`, 0, legacyDepID)
+}
+
 func assertCount(t *testing.T, db *Database, query string, want int, args ...any) {
 	t.Helper()
 	var got int

--- a/scripts/install-cli.ps1
+++ b/scripts/install-cli.ps1
@@ -81,10 +81,13 @@ foreach ($line in (Get-Content -LiteralPath $ChecksumsTmp)) {
         break
     }
 }
-Remove-Item -Force $ChecksumsTmp -ErrorAction SilentlyContinue
 if (-not $Want) {
-    Die "checksum entry for $Asset missing from checksums.txt (first 5 lines were:`n$((Get-Content -LiteralPath $ChecksumsTmp -TotalCount 5 -ErrorAction SilentlyContinue) -join "`n"))"
+    # Read before the delete below, or the diagnostic quotes a file that is gone.
+    $Head = (Get-Content -LiteralPath $ChecksumsTmp -TotalCount 5 -ErrorAction SilentlyContinue) -join "`n"
+    Remove-Item -Force $ChecksumsTmp -ErrorAction SilentlyContinue
+    Die "checksum entry for $Asset missing from checksums.txt (first 5 lines were:`n$Head)"
 }
+Remove-Item -Force $ChecksumsTmp -ErrorAction SilentlyContinue
 $Got = (Get-FileHash -Algorithm SHA256 $TmpExe).Hash.ToLower()
 if ($Want -ne $Got) { Die "checksum mismatch: want=$Want got=$Got" }
 Log "checksum OK"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,6 +96,9 @@ pacman_run() {
 }
 
 usage() {
+    # --help exits from parse_args, before main() calls resolve_self_url, so
+    # derive it here or the printed curl one-liner has an empty URL.
+    resolve_self_url
     cat <<EOF
 Orva installer — install the server (Docker or bare-metal) or just the CLI.
 
@@ -453,7 +456,9 @@ detect_existing() {
     EXISTING_KIND="none"; EXISTING_VERSION=""
     if [ -x "$PREFIX/bin/orva" ]; then
         EXISTING_KIND="bare"
-        EXISTING_VERSION=$("$PREFIX/bin/orva" --version 2>/dev/null | head -n1 || echo "")
+        # cobra prints "orva vX.Y.Z"; strip the name so this compares against
+        # VERSION ("vX.Y.Z") instead of never matching.
+        EXISTING_VERSION=$("$PREFIX/bin/orva" --version 2>/dev/null | head -n1 | awk '{print $NF}' || echo "")
     fi
     if have docker && docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q '^orva$'; then
         [ "$EXISTING_KIND" = "none" ] && EXISTING_KIND="docker"


### PR DESCRIPTION
PR 6 of the bug-hunt cleanup: the build-queue race, the UUIDv7 dangle, and the three low-severity installer papercuts.

## Concurrent builds wrote into each other's logs

The queue runs `runtime.NumCPU()` workers, and every one set `Logger` on the **single shared `*Builder`**, then nil'd it in a defer. Two overlapping builds cross-attributed their `pip`/`npm` output, and whichever finished first cleared the writer out from under the rest — silently dropping their remaining lines.

**It is a genuine data race, not just a mix-up.** A probe using the old pattern under `-race`:

```
WARNING: DATA RACE
Write at 0x00c0000ae208 by goroutine 10:
Previous read at 0x00c0000ae208 by goroutine 10:
```

Each job now builds through its own copy. The struct has no embedded mutex and its shared state (`FnLock`, `DB`) is held by pointer, so a shallow copy keeps the per-function build lock genuinely shared.

## The UUIDv7 migration left `functions.active_deployment_id` dangling

It holds a `deployments.id`, but is added by `ALTER TABLE ... ADD COLUMN` with **no foreign key** — so `PRAGMA foreign_key_list` cannot discover it, and it was missing from the `deployments` `softRefs` list. That is exactly the shape `CONTRACT.md` §9 warns about with `channel_functions`.

Deployment ids were rewritten; the pointer was not. And `backfillActiveDeployment` **cannot** repair it — it only fills the column `WHERE active_deployment_id = ''`, never an id that is merely wrong.

Test fails on the old code (`count = 0, want 1`) and passes with the fix.

## Three installer papercuts

| | |
|---|---|
| `install.sh --help` | printed its own `curl` one-liner with an **empty URL** — `--help` exits from `parse_args`, before `main()` derives `SELF_URL` |
| `install.sh:973` | the "already at this version" check **could never be true**: it compared `orva --version`'s output (`orva vX.Y.Z`) against `VERSION` (`vX.Y.Z`), so an idempotent re-run always reinstalled |
| `install-cli.ps1:84` | deleted `checksums.txt` one line *before* quoting its first five lines, so the missing-entry diagnostic was **always blank** — the one message that would tell you what went wrong |

Verified: `--help` now prints the real URL, and the version strip yields `v2026.08.28`.

## Note

The fourth low-severity finding — docs claiming job/cron ids arrive prefixed `job_` / `cron_` — is fixed in #72, not duplicated here.

## Verification

`go build` OK, `go vet` clean, 25 packages green, shellcheck clean, `-race` clean on `builder` (20.8s) and `database` (102.4s).
