### PR TITLE
Keep function secrets out of the host process list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ before it.
 
 ### Fixed
 
+- **Function secrets were visible in the host process list.** Decrypted
+  secrets and each worker's `ORVA_INTERNAL_TOKEN` were passed to nsjail as
+  `--env KEY=VALUE` command-line arguments. `/proc/<pid>/cmdline` is
+  world-readable, and the shipped compose file runs with `pid: host`, so every
+  value was readable by any local user for as long as the call ran — and the
+  full argument list was written to the debug log as well. Values now travel in
+  the sandbox process's environment and the command line carries only the
+  variable name. `/proc/<pid>/environ` is readable only by the user Orva runs
+  as, and by root. Nothing changes inside the sandbox: a function sees exactly
+  the same variables it did before.
+
 - **Four dashboard pages showed, or acted on, the function you were looking at
   before.** Every view is cached in a `<keep-alive>`, and a cached view is not
   unmounted — it stays alive with a live `useRoute()`, so it kept reacting to

--- a/backend/internal/sandbox/sandbox.go
+++ b/backend/internal/sandbox/sandbox.go
@@ -127,7 +127,7 @@ func Execute(ctx context.Context, cfg ExecConfig) *ExecResult {
 		return &ExecResult{Error: err, Duration: time.Since(start)}
 	}
 
-	args, err := buildArgs(cfg, rootfs, entrypoint)
+	args, childEnv, err := buildArgs(cfg, rootfs, entrypoint)
 	if err != nil {
 		return &ExecResult{Error: err, Duration: time.Since(start)}
 	}
@@ -138,6 +138,8 @@ func Execute(ctx context.Context, cfg ExecConfig) *ExecResult {
 	// nsjail itself carries the required capabilities via setcap (installed
 	// by `orva setup` or baked into the Docker image). No sudo wrapper.
 	cmd := exec.CommandContext(ctx, cfg.NsjailBin, args...)
+	// Values live here, not in argv; nsjail forwards them by name.
+	cmd.Env = append(os.Environ(), childEnv...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -220,7 +222,11 @@ func resolveRuntime(cfg ExecConfig) (rootfs, entrypoint string, err error) {
 	return rootfs, entrypoint, nil
 }
 
-func buildArgs(cfg ExecConfig, rootfs, entrypoint string) ([]string, error) {
+// buildArgs returns nsjail's argv and the environment its child process must
+// carry. Values go in the env, never argv: /proc/<pid>/cmdline is world-readable
+// and the shipped compose runs pid: host, so a secret in argv is readable by any
+// local user for the life of the call. /proc/<pid>/environ is owner-only.
+func buildArgs(cfg ExecConfig, rootfs, entrypoint string) (args, childEnv []string, err error) {
 	// Prefer user namespaces for nsjail's mount/chroot setup. On hosts that
 	// restrict unprivileged user namespaces, the bare-metal installer grants
 	// the nsjail executable the narrow capability set it needs and exports
@@ -229,14 +235,13 @@ func buildArgs(cfg ExecConfig, rootfs, entrypoint string) ([]string, error) {
 	// NOTE: --time_limit intentionally dropped; Go-side context.WithTimeout
 	// + Worker.Kill() handles timeouts with millisecond resolution and
 	// avoids the skew from nsjail's whole-second limit.
-	var args []string
 
 	// The compiled egress policy is loaded via --config, which MUST be the very
 	// first argument — see egressConfigArgs for why, and for the fail-closed
 	// contract when no policy is available.
 	prefix, err := egressConfigArgs(cfg.NetworkMode, cfg.EgressPolicyPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	args = append(args, prefix...)
 
@@ -300,17 +305,25 @@ func buildArgs(cfg ExecConfig, rootfs, entrypoint string) ([]string, error) {
 	// Inject env vars + secrets. nsjail takes --env KEY=VAL; an --env with
 	// no '=' passes the host-side value through, which we never want for
 	// security. Always format as KEY=VAL explicitly.
+	// --env NAME (no '=') tells nsjail to forward the value from its own
+	// environment, which is what keeps secrets out of argv. Safe here only
+	// because childEnv is explicit: nothing is forwarded that we did not put
+	// there by name.
 	for k, v := range cfg.Env {
 		if k == "" {
 			continue
 		}
-		args = append(args, "--env", k+"="+v)
+		args = append(args, "--env", k)
+		childEnv = append(childEnv, k+"="+v)
 	}
 	// Also tell the Python/Node adapter about Orva context via env.
-	args = append(args,
-		"--env", "ORVA_FUNCTION_ID="+getenvOr(cfg.Env, "ORVA_FUNCTION_ID", ""),
-		"--env", "ORVA_EXECUTION_ID="+getenvOr(cfg.Env, "ORVA_EXECUTION_ID", ""),
-	)
+	for _, k := range []string{"ORVA_FUNCTION_ID", "ORVA_EXECUTION_ID"} {
+		if _, ok := cfg.Env[k]; ok {
+			continue // already forwarded above
+		}
+		args = append(args, "--env", k)
+		childEnv = append(childEnv, k+"="+getenvOr(cfg.Env, k, ""))
+	}
 
 	args = append(args, "--", entrypoint)
 
@@ -321,7 +334,7 @@ func buildArgs(cfg ExecConfig, rootfs, entrypoint string) ([]string, error) {
 		args = append(args, "/opt/orva/adapter.js")
 	}
 
-	return args, nil
+	return args, childEnv, nil
 }
 
 // egressConfigArgs returns the `--config <policy>` prefix an egress jail must

--- a/backend/internal/sandbox/sandbox_test.go
+++ b/backend/internal/sandbox/sandbox_test.go
@@ -40,7 +40,7 @@ func TestBuildArgs_NoEgressByDefault(t *testing.T) {
 				CodeDir:     "/tmp/code",
 				NetworkMode: tc.mode,
 			}
-			args, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.py")
+			args, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.py")
 			if err != nil {
 				t.Fatalf("buildArgs: %v", err)
 			}
@@ -67,7 +67,7 @@ func TestBuildArgs_EgressAddsUserNet(t *testing.T) {
 		NetworkMode:      "egress",
 		EgressPolicyPath: testPolicyFile(t),
 	}
-	args, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
+	args, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
 	if err != nil {
 		t.Fatalf("buildArgs: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestBuildArgs_EgressWithoutPolicyPathIsAnError(t *testing.T) {
 		CodeDir:     "/tmp/code",
 		NetworkMode: "egress",
 	}
-	if _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js"); !errors.Is(err, ErrEgressPolicyMissing) {
+	if _, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js"); !errors.Is(err, ErrEgressPolicyMissing) {
 		t.Fatalf("want ErrEgressPolicyMissing, got %v", err)
 	}
 }
@@ -105,7 +105,7 @@ func TestBuildArgs_ConfigFlagIsFirst(t *testing.T) {
 		Env:              map[string]string{"SECRET": "value"},
 		SeccompPolicy:    "POLICY x { ALLOW { read } }",
 	}
-	args, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
+	args, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
 	if err != nil {
 		t.Fatalf("buildArgs: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestBuildArgs_DisableUsernsTracksTheEnvVar(t *testing.T) {
 
 	t.Run("enabled", func(t *testing.T) {
 		t.Setenv("ORVA_DISABLE_USERNS", "1")
-		args, err := buildArgs(newCfg(), "/tmp/rootfs", "/tmp/code/handler.js")
+		args, _, err := buildArgs(newCfg(), "/tmp/rootfs", "/tmp/code/handler.js")
 		if err != nil {
 			t.Fatalf("buildArgs: %v", err)
 		}
@@ -181,7 +181,7 @@ func TestBuildArgs_DisableUsernsTracksTheEnvVar(t *testing.T) {
 	for _, value := range []string{"", "0", "true", "yes"} {
 		t.Run("disabled/"+value, func(t *testing.T) {
 			t.Setenv("ORVA_DISABLE_USERNS", value)
-			args, err := buildArgs(newCfg(), "/tmp/rootfs", "/tmp/code/handler.js")
+			args, _, err := buildArgs(newCfg(), "/tmp/rootfs", "/tmp/code/handler.js")
 			if err != nil {
 				t.Fatalf("buildArgs: %v", err)
 			}
@@ -198,7 +198,7 @@ func TestBuildArgs_DisableUsernsTracksTheEnvVar(t *testing.T) {
 // entirely, making a silently-dropped policy rule invisible.
 func TestBuildArgs_UsesWarningLogLevel(t *testing.T) {
 	cfg := ExecConfig{Language: Python, CodeDir: "/tmp/code"}
-	args, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.py")
+	args, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.py")
 	if err != nil {
 		t.Fatalf("buildArgs: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestBuildArgs_AlwaysHasOnceMode(t *testing.T) {
 		Language: Python,
 		CodeDir:  "/tmp/code",
 	}
-	args, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.py")
+	args, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.py")
 	if err != nil {
 		t.Fatalf("buildArgs: %v", err)
 	}
@@ -485,7 +485,7 @@ func TestBuildArgs_EgressPolicyFileMustExist(t *testing.T) {
 		NetworkMode:      "egress",
 		EgressPolicyPath: filepath.Join(t.TempDir(), "does-not-exist.cfg"),
 	}
-	_, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
+	_, _, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
 	if !errors.Is(err, ErrEgressPolicyMissing) {
 		t.Fatalf("want ErrEgressPolicyMissing for a vanished policy file, got %v", err)
 	}
@@ -525,6 +525,58 @@ func TestKafelAliasesRespectTheArchFilter(t *testing.T) {
 		if strings.TrimSpace(tok) == "open" {
 			t.Fatal("an arm64-unsupported alias reached the compiled policy; " +
 				"Kafel would fail to compile it and no sandbox would start")
+		}
+	}
+}
+
+// TestBuildArgs_SecretsNeverAppearInArgv pins the fix for secrets leaking via
+// /proc/<pid>/cmdline. That file is world-readable and the shipped compose runs
+// `pid: host`, so a value in argv was readable by any local user for the life of
+// the call. Values now travel in the child's environment; argv carries only the
+// NAME, which nsjail resolves from its own env.
+//
+// Fails on the pre-fix code: argv contained "SECRET=hunter2".
+func TestBuildArgs_SecretsNeverAppearInArgv(t *testing.T) {
+	const secret = "hunter2-do-not-leak"
+	cfg := ExecConfig{
+		Language:    Node,
+		CodeDir:     "/tmp/code",
+		NetworkMode: "none",
+		Env: map[string]string{
+			"SECRET":              secret,
+			"ORVA_INTERNAL_TOKEN": "tok-" + secret,
+			"ORVA_FUNCTION_ID":    "fn-1",
+		},
+	}
+	args, childEnv, err := buildArgs(cfg, "/tmp/rootfs", "/tmp/code/handler.js")
+	if err != nil {
+		t.Fatalf("buildArgs: %v", err)
+	}
+
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, secret) {
+		t.Errorf("secret value leaked into argv: %s", joined)
+	}
+	// The names must still be forwarded, or the function loses its env.
+	for _, name := range []string{"SECRET", "ORVA_INTERNAL_TOKEN", "ORVA_FUNCTION_ID"} {
+		if !hasPair(args, "--env", name) {
+			t.Errorf("--env %s missing from argv", name)
+		}
+	}
+	// ...and the values must be in the child env exactly once.
+	want := map[string]bool{
+		"SECRET=" + secret:                  false,
+		"ORVA_INTERNAL_TOKEN=tok-" + secret: false,
+		"ORVA_FUNCTION_ID=fn-1":             false,
+	}
+	for _, kv := range childEnv {
+		if _, ok := want[kv]; ok {
+			want[kv] = true
+		}
+	}
+	for kv, seen := range want {
+		if !seen {
+			t.Errorf("child env missing %q; got %v", kv, childEnv)
 		}
 	}
 }

--- a/backend/internal/sandbox/worker.go
+++ b/backend/internal/sandbox/worker.go
@@ -99,7 +99,7 @@ func Spawn(ctx context.Context, cfg ExecConfig) (*Worker, error) {
 	if err != nil {
 		return nil, err
 	}
-	args, err := buildArgs(cfg, rootfs, entrypoint)
+	args, childEnv, err := buildArgs(cfg, rootfs, entrypoint)
 	if err != nil {
 		return nil, err
 	}
@@ -108,6 +108,8 @@ func Spawn(ctx context.Context, cfg ExecConfig) (*Worker, error) {
 		"egress_policy_gen", cfg.EgressPolicyGen)
 
 	cmd := exec.Command(cfg.NsjailBin, args...)
+	// Values live here, not in argv; nsjail forwards them by name.
+	cmd.Env = append(os.Environ(), childEnv...)
 
 	stdinPipe, err := cmd.StdinPipe()
 	if err != nil {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -659,11 +659,21 @@ function still runs in the user-namespace-isolated sandbox at runtime.
 
 > "Can a function read another function's secrets?"
 
-No. Secrets are decrypted by orvad and injected as `--env KEY=VAL`
-flags at sandbox spawn time (`sandbox.go`, `buildArgs()`). Each sandbox sees
-only its own function's secrets in its environment; the secret
-material never leaves orvad and is never readable from any sandbox
-filesystem.
+No. Secrets are decrypted by orvad and passed into the sandbox's environment
+at spawn time (`sandbox.go`, `buildArgs()`). Each sandbox sees only its own
+function's secrets; the secret material never leaves orvad and is never
+readable from any sandbox filesystem.
+
+> "Can a user on the host read a function's secrets?"
+
+Not from the process list. Values travel in the nsjail child's environment and
+argv carries only the variable *name* — `--env SECRET`, which nsjail resolves
+from its own environment. This matters because `/proc/<pid>/cmdline` is
+world-readable and the shipped compose runs `pid: host`, so anything in argv is
+visible to every local user for as long as the call runs.
+`/proc/<pid>/environ` is owner-only (mode 400), so the value is readable only
+by the user orvad runs as, and by root. Earlier builds passed
+`--env KEY=VAL` in argv and also logged the full argv at debug level.
 
 > "Can a function read another function's code?"
 


### PR DESCRIPTION
The last of the 21 bug-hunt findings.

## The defect

Decrypted function secrets and each worker's `ORVA_INTERNAL_TOKEN` were passed to nsjail as `--env KEY=VALUE` **argv entries**.

`/proc/<pid>/cmdline` is world-readable, and the shipped `docker-compose.yml` runs with **`pid: host`** — so every secret value was readable by any local user for as long as the call ran. `worker.go` also logs the full argv at debug level, so they reached the log too.

## The fix

Values travel in the nsjail child's environment; argv carries only the **name** — `--env SECRET`, which nsjail resolves from its own environment. `/proc/<pid>/environ` is mode 400: the user orvad runs as, and root.

Nothing changes inside the sandbox. A function sees exactly the variables it did before.

**On the comment that warned against this shape.** The pass-by-name form was previously avoided with the note that an `--env` without `=` *"passes the host-side value through, which we never want for security"*. That holds only while the forwarded set is implicit. `buildArgs` now returns the child environment explicitly alongside argv, so nothing is forwarded that wasn't put there by name — and the two can't drift, because the same loop writes both.

## Scope

**Execution sandbox only.** The build jail (`buildJailArgs`) keeps `KEY=VAL` in argv: its variables are `HOME`, `TMPDIR` and npm/pip cache paths — none secret — and `build_test.go` pins them. Two call sites (`sandbox.go` one-shot exec, `worker.go` warm spawn), both wired.

## Verification

The new test fails on the old form and names the leak verbatim:

```
secret value leaked into argv: ... --env SECRET=hunter2-do-not-leak ...
```

It also asserts the names are still forwarded and the values land in the child env — a fix that quietly dropped the env would otherwise pass a "no secret in argv" check.

`go build` OK, `go vet` clean, 25 packages green, `gofmt` clean, `-race` clean on `sandbox` (1.9s) and `pool` (15.2s).

## Docs

`docs/SECURITY.md` answered *"can a function read another function's secrets?"* and never the host-side question. It does now, with the `cmdline` vs `environ` distinction and the `pid: host` caveat that makes it matter.
