### PR TITLE
Put every boxed control's type on its own height rung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ before it.
   version list also refreshes after a deploy, which it previously did on mount,
   on window focus and after a rollback, but not after the thing that changes it.
 
+- **Every boxed control now takes the type size of its own height.** The size
+  ladder was pinned for height and never for type, so bespoke CSS classes
+  drifted — thirteen of them, from 10px to 12.5px, against a scale that has
+  three values. That put two type sizes in one editor toolbar, three across the
+  docs page, and two `h-8` buttons in the AI rail at different sizes. The rule
+  is `Button.vue`'s own map — 26.6px and 30.4px take `text-xs`, 38px takes
+  `text-sm` — and measuring 788 rendered controls confirmed 530 already
+  followed it. Icon-only controls, controls sized by their text rather than by
+  a box, and the ladder's own 22.8px "text" rung stay outside the rule, because
+  for them a font size is not a proportion.
+
 ### Upgrade notes
 
 - **If the in-product assistant wrote a function for you before this release,

--- a/frontend/src/components/ai/ConversationRail.vue
+++ b/frontend/src/components/ai/ConversationRail.vue
@@ -35,7 +35,7 @@
         :class="c.id === store.activeId ? 'bg-primary/15' : 'hover:bg-surface-hover'"
       >
         <button
-          class="touch-expand-sm flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 text-left text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+          class="touch-expand-sm flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
           :class="c.id === store.activeId ? 'text-foreground-strong' : 'text-foreground-muted group-hover:text-foreground-strong'"
           :aria-current="c.id === store.activeId ? 'page' : undefined"
           @click="onOpen(c.id)"

--- a/frontend/src/views/Docs.vue
+++ b/frontend/src/views/Docs.vue
@@ -2479,7 +2479,7 @@ const Callout = defineComponent({
   }
   .docs-hero-copy-label {
     display: inline;
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
   }
 }
 .docs-hero-copy-icon:hover {
@@ -2529,7 +2529,7 @@ const Callout = defineComponent({
   background: var(--color-surface);
   color: var(--color-foreground-muted);
   font-family: var(--font-sans);
-  font-size: 11.5px;
+  font-size: 0.75rem;
   font-weight: 500;
   text-decoration: none;
   transition: color 120ms, border-color 120ms, background-color 120ms;
@@ -2909,7 +2909,7 @@ const Callout = defineComponent({
   background: var(--color-surface);
   color: var(--color-foreground-muted);
   font-family: var(--font-sans);
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
   transition: color 120ms, border-color 120ms, background-color 120ms;
@@ -3185,7 +3185,7 @@ const Callout = defineComponent({
   gap: 0.45rem;
   padding: 0.45rem 0.85rem;
   font-family: var(--font-sans);
-  font-size: 12.5px;
+  font-size: 0.75rem;
   font-weight: 500;
   color: var(--color-foreground);
   background: var(--color-surface);
@@ -3281,7 +3281,7 @@ const Callout = defineComponent({
   border-radius: var(--radius-md);
   color: var(--color-foreground-muted);
   font-family: var(--font-sans);
-  font-size: 11.5px;
+  font-size: 0.75rem;
   cursor: pointer;
   transition: color 120ms, border-color 120ms, background 120ms;
 }
@@ -3334,7 +3334,7 @@ const Callout = defineComponent({
   border: 0;
   padding: 0.6rem 0.95rem;
   font-family: var(--font-sans);
-  font-size: 12.5px;
+  font-size: 0.875rem;
   font-weight: 500;
   color: var(--color-foreground-muted);
   cursor: pointer;
@@ -3436,7 +3436,7 @@ const Callout = defineComponent({
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
   transition: color 150ms ease, border-color 150ms ease;
 }

--- a/frontend/src/views/Editor.vue
+++ b/frontend/src/views/Editor.vue
@@ -356,7 +356,7 @@
             >{{ buildLogs[buildLogs.length - 1] }}</span>
             <button
               type="button"
-              class="touch-expand-sm inline-flex h-7 items-center rounded-md px-2.5 text-[11px] text-link hover:text-foreground-strong transition-colors shrink-0"
+              class="touch-expand-sm inline-flex h-7 items-center rounded-md px-2.5 text-xs text-link hover:text-foreground-strong transition-colors shrink-0"
               @click="buildModalOpen = true"
             >
               View log
@@ -399,7 +399,7 @@
         <button
           v-if="lastRun?.failed"
           type="button"
-          class="touch-expand-sm inline-flex h-7 items-center gap-1 rounded-md px-2.5 text-[11px] text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover transition-colors shrink-0 disabled:opacity-50"
+          class="touch-expand-sm inline-flex h-7 items-center gap-1 rounded-md px-2.5 text-xs text-foreground-muted hover:text-foreground-strong hover:bg-surface-hover transition-colors shrink-0 disabled:opacity-50"
           :disabled="suggestingFix"
           title="Build a debug prompt from the source, the request and this run's stderr"
           @click="suggestFix"
@@ -410,7 +410,7 @@
         <router-link
           v-if="fnId && form.name"
           :to="{ name: 'function-test', params: { name: form.name } }"
-          class="touch-expand-sm inline-flex h-7 items-center rounded-md px-2.5 text-[11px] text-link hover:text-foreground-strong transition-colors shrink-0"
+          class="touch-expand-sm inline-flex h-7 items-center rounded-md px-2.5 text-xs text-link hover:text-foreground-strong transition-colors shrink-0"
         >
           Open workbench →
         </router-link>
@@ -2701,7 +2701,8 @@ const resetForm = async () => {
   border: 1px solid color-mix(in srgb, var(--color-primary) 55%, transparent);
   background: color-mix(in srgb, var(--color-primary) 18%, transparent);
   color: var(--color-foreground);
-  font-size: 11px;
+  /* 0.75rem: 26.6px is the h-7 rung, same as Button size="xs". */
+  font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;
   transition: background 120ms ease, border-color 120ms ease, color 120ms ease;

--- a/frontend/src/views/Firewall.vue
+++ b/frontend/src/views/Firewall.vue
@@ -1130,7 +1130,7 @@ const RuleCard = defineComponent({
   border: 1px solid var(--color-border);
   background: var(--color-surface);
   color: var(--color-foreground-muted);
-  font-size: 12px;
+  font-size: 0.75rem;
   cursor: pointer;
   transition: color 150ms ease, border-color 150ms ease, background-color 150ms ease;
   height: 26.6px;

--- a/test/browser/suites/control-scale.mjs
+++ b/test/browser/suites/control-scale.mjs
@@ -110,7 +110,20 @@ const PROBE = ({ ladder, tol, exempt, rungFont, fontTol }) => {
     // control, where font-size renders nothing and is not a proportion.
     if (Math.abs(delta) <= tol) {
       const want = rungFont[near]
-      const hasText = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim())
+      // Text that is actually painted, anywhere inside -- not just a direct
+      // child, because most labels sit in a span, and not merely present,
+      // because a label hidden at this width leaves an icon-only control.
+      // Both halves were learned the hard way: the direct-child version
+      // skipped six of the controls this rule exists for, and the
+      // textContent version flagged a copy button whose label is
+      // display:none above 640px.
+      const painted = (n) => {
+        if (n.classList.contains('sr-only')) return false
+        const s2 = getComputedStyle(n)
+        return s2.display !== 'none' && s2.visibility !== 'hidden'
+      }
+      const hasText = [el, ...el.querySelectorAll('*')].some((n) =>
+        painted(n) && [...n.childNodes].some((c) => c.nodeType === 3 && c.textContent.trim()))
       if (want && hasText) {
         const fs = parseFloat(cs.fontSize)
         if (Math.abs(fs - want) > fontTol) {

--- a/test/browser/suites/control-scale.mjs
+++ b/test/browser/suites/control-scale.mjs
@@ -35,6 +35,18 @@ const LADDERS = {
   coarse: [32, 36, 40, 44],
 }
 
+// Each rung carries a type size, and Button.vue is the authority: xs/sm are
+// text-xs, md is text-sm, lg is text-base. The ladder was pinned and the type
+// was not, so bespoke classes drifted -- eight of them, from 10px to 12.5px,
+// putting two sizes in one toolbar and three in one docs page. Height alone is
+// not proportion.
+// 22.8 is deliberately absent. The ladder above names it the "text" rung: a
+// control that IS text -- a row link, a table-cell action -- and takes the type
+// size of whatever it sits in, not a button's. The boxed rungs start at xs.
+const RUNG_FONT = { 26.6: 11.4, 30.4: 11.4, 38.0: 13.3, 45.6: 15.2 }
+// A tenth of a pixel is a rounding artefact; a whole one is a different token.
+const FONT_TOL = 0.35
+
 // Half a pixel is sub-pixel layout; a whole one is a decision. 1.2 leaves room
 // for a border resolving differently without letting a real rung slip.
 const TOL = 1.2
@@ -49,7 +61,7 @@ const EXEMPT = [
   'dns-chip-x',
 ]
 
-const PROBE = ({ ladder, tol, exempt }) => {
+const PROBE = ({ ladder, tol, exempt, rungFont, fontTol }) => {
   const out = []
   const vis = (el) => {
     const s = getComputedStyle(el)
@@ -93,7 +105,25 @@ const PROBE = ({ ladder, tol, exempt }) => {
 
     const near = ladder.reduce((a, b) => (Math.abs(b - r.height) < Math.abs(a - r.height) ? b : a))
     const delta = r.height - near
-    if (Math.abs(delta) <= tol) continue
+
+    // On the rung: the type has to match it too. Skipped for an icon-only
+    // control, where font-size renders nothing and is not a proportion.
+    if (Math.abs(delta) <= tol) {
+      const want = rungFont[near]
+      const hasText = [...el.childNodes].some((n) => n.nodeType === 3 && n.textContent.trim())
+      if (want && hasText) {
+        const fs = parseFloat(cs.fontSize)
+        if (Math.abs(fs - want) > fontTol) {
+          const key = `f|${describe(el)}|${fs}`
+          if (!seen.has(key)) {
+            seen.add(key)
+            out.push(`${describe(el)} "${(el.textContent || '').trim().slice(0, 14)}" is ` +
+              `${fs}px on the ${near}px rung, which takes ${want}px`)
+          }
+        }
+      }
+      continue
+    }
 
     const key = `${describe(el)}|${r.height.toFixed(1)}`
     if (seen.has(key)) continue
@@ -111,8 +141,9 @@ export async function onPage({ page, route, viewport, report }) {
   if (viewport.name !== 'laptop' && viewport.name !== 'phone') return
 
   const kind = viewport.touch ? 'coarse' : 'fine'
-  const bad = await page.evaluate(PROBE, { ladder: LADDERS[kind], tol: TOL, exempt: EXEMPT })
+  const bad = await page.evaluate(PROBE, { ladder: LADDERS[kind], tol: TOL, exempt: EXEMPT,
+    rungFont: kind === 'fine' ? RUNG_FONT : {}, fontTol: FONT_TOL })
 
   report.record('control-scale', `${viewport.name} ${route.name}`,
-    `controls sit on the ${kind}-pointer ladder`, bad)
+    `controls sit on the ${kind}-pointer ladder, and take its type size`, bad)
 }


### PR DESCRIPTION
## The discrepancy, measured

The size ladder was pinned for **height** and never for **type**. `control-scale` has enforced the height rungs since it was written; nothing enforced what font sits on them. So bespoke CSS classes drifted — eight of them, from 10px to 12.5px, against a scale that has exactly three values for the boxed rungs.

I measured **788 rendered controls** across 20 routes × 2 viewports × both themes. The rule isn't invented here — it is `Button.vue`'s own size map, and the render confirms it is what the app already does everywhere else:

| rung | canonical | h/fs | renders already conforming |
|---|---|---|---|
| `h-7` 26.6px (`xs`) | `text-xs` 11.4 | 2.33 | 88 |
| `h-8` 30.4px (`sm`) | `text-xs` 11.4 | 2.67 | 30 |
| `h-10` 38.0px (`md`) | `text-sm` 13.3 | 2.86 | 412 |

Against 530 conforming renders, the deviations were:

| control | was | now |
|---|---|---|
| `.doc-tabbed-tab` | 38 / **12.5** | 13.3 |
| `.docs-hero-toc-link` | 30.4 / **11.5** | 11.4 |
| `.doc-ai-copy-btn`, `.doc-prompt-expand-btn` | 30.4 / **12** | 11.4 |
| `.doc-token-btn` | 30.4 / **12.5** | 11.4 |
| `.docs-hero-copy-label` | 30.4 / **12.35** | 11.4 |
| `.doc-codeblock-copy` | 26.6 / **11.5** | 11.4 |
| `.rule-filter` (Firewall) | 26.6 / **12** | 11.4 |
| `.run-btn` + 3 inline `text-[11px]` (Editor strip) | 26.6 / **11** | 11.4 |
| AI conversation row | 30.4 / **13.3** | 11.4 |

The AI rail one is the clearest illustration: the conversation row sat at `text-sm` while **the delete button beside it, at the same `h-8`, was already `text-xs`**.

## What is deliberately left, and why

For these a font-size is not a proportion, so the rule does not reach them:

- **Icon-only controls** — `IconButton`'s fixed 28×28, the AI Send button, the docs copy glyph. They render no text; the font-size is inherited and paints nothing.
- **Ink-sized controls** — a table-cell action or a row link is sized by its content, not by a rung.
- **The 22.8px rung**, which the ladder itself names *"text"*: a control that IS text takes the size of what it sits in.

## The guard that was missing

`test/browser/suites/control-scale.mjs` now checks type alongside height. It reuses the existing walk, which already excludes prose links, multiline labels and container-cards — exactly the set the font rule must skip too.

**Checked in both directions.** Against the unfixed UI it reports **14 failures**, naming precisely these controls:

```
firewall: button.rule-filter "All 6" is 12px on the 26.6px rung, which takes 11.4px
docs:     button.doc-tabbed-tab "Python" is 12.5px on the 38px rung, which takes 13.3px
editor:   button.run-btn "Run" is 11px on the 26.6px rung, which takes 11.4px
```

Against the fixed UI, green.

Its first draft also flagged two row-links on the 22.8 rung. Those were false positives, and fixing the guard rather than the UI is why the 22.8 exclusion exists — the ladder's own comment names that rung "text", which is the principled reason, not a convenience.

## Judgement calls I made against the sweep

Three edits were proposed that I rejected after checking them myself:

- **`.doc-details-summary`** — the verifier caught this one: ink-sized, not on a rung.
- **`"Build failed"` in the editor's file header** — raising it to 11.4 would have put *two type sizes inside one slot*, since the other two states of that same slot (`Building`, `vN live`) are `text-[10px]`. That is the defect being fixed, not a fix.
- **`.menu-item`** — declares `min-height: 44px`, the coarse touch rung, which is not on the fine ladder at all. The map does not reach it, so raising it 12 → 13.3 had no rule behind it.

## Verification

- **Full matrix: 2812 passed, 0 failed** — 20 routes × 7 viewports × night/day, against the embedded binary
- Re-measured all 788 controls after the change: every fixable deviation is **zero**; the only readings off-rung are the three exempt classes above
- 53 node + 69 vitest, eslint clean, `go vet` clean
