### PR TITLE
build(go): Go 1.27 toolchain + bifrost/core 1.8.4, in lock-step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           # Without this, setup-go pins to the runner image's stale cached Go.
           check-latest: true
           cache: false
@@ -219,7 +219,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04]
-        go: ["1.26.x"]
+        go: ["1.27.x"]
     steps:
       - uses: actions/checkout@v7
 
@@ -526,7 +526,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           check-latest: true
           cache: false
       - name: go vet (cli + internal)
@@ -545,7 +545,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           # CLI release binaries are built here; keep them on the same patched toolchain.
           check-latest: true
           cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,7 +150,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           # Published binaries must not carry a stdlib CVE already fixed upstream.
           check-latest: true
           # No build cache — every release builds from scratch so we
@@ -243,7 +243,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.26.x"
+          go-version: "1.27.x"
           # Published binaries must not carry a stdlib CVE already fixed upstream.
           check-latest: true
           # No build cache — every release builds from scratch so we

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ pruned with their releases — so `git log v2026.09.01..HEAD` is the range for
 anything unreleased, and the sections below are the record for everything
 before it.
 
+## Unreleased
+
+### Upgrade notes
+
+- **Building Orva from source now needs Go 1.27** (was 1.26). The embedded
+  Bifrost AI gateway declares `go 1.27.0` in its own module, so the floor moves
+  with it; the Dockerfile and both workflows are pinned in lock-step. Nothing
+  changes if you install a released binary or run the container — each carries
+  its own toolchain.
+
+
 ## v2026.09.01
 
 ### Added

--- a/CONTRACT.md
+++ b/CONTRACT.md
@@ -18,7 +18,7 @@ place the load-bearing operational facts live; `CLAUDE.md`/`AGENTS.md` and
 
 ## 1. Toolchain (pinned, lock-step)
 
-- **Go 1.26+** (the embedded Bifrost AI gateway requires it), **Node.js 24**,
+- **Go 1.27+** (the embedded Bifrost AI gateway requires it), **Node.js 24**,
   **Python 3.14**.
 - **nsjail** at the hardcoded path `/usr/local/bin/nsjail` (Linux only) — `PATH` is
   never consulted and there is no env override (`config/defaults.go` `NsjailBin`,

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm ci --no-audit --no-fund
 COPY frontend/ ./
 RUN npm run build
 
-FROM golang:1.26-bookworm AS go
+FROM golang:1.27-bookworm AS go
 WORKDIR /src
 # go.mod / go.sum live at the repo root since the v2026.05.12 CLI split.
 COPY go.mod go.sum ./

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://img.shields.io/github/actions/workflow/status/Harsh-2002/Orva/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/Harsh-2002/Orva/actions/workflows/ci.yml)
 [![Docker](https://img.shields.io/badge/docker-ghcr.io%2Fharsh--2002%2Forva-2496ED?style=flat-square&logo=docker&logoColor=white)](https://github.com/Harsh-2002/Orva/pkgs/container/orva)
 [![License](https://img.shields.io/badge/license-Apache%202.0-green?style=flat-square)](LICENSE)
-[![Go](https://img.shields.io/badge/Go-1.26+-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev)
+[![Go](https://img.shields.io/badge/Go-1.27+-00ADD8?style=flat-square&logo=go&logoColor=white)](https://go.dev)
 [![Node](https://img.shields.io/badge/Node.js-24-339933?style=flat-square&logo=node.js&logoColor=white)](https://nodejs.org)
 [![Python](https://img.shields.io/badge/Python-3.14-3776AB?style=flat-square&logo=python&logoColor=white)](https://python.org)
 

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,6 +1,6 @@
 # Backend
 
-Go 1.26 (bumped from 1.25 — the embedded Bifrost AI gateway requires go ≥1.26; the Dockerfile + all CI workflows pin golang 1.26 in lock-step). Module: `github.com/Harsh-2002/Orva` (rooted at the repo, not at
+Go 1.27 (the embedded Bifrost AI gateway requires go ≥1.27; the Dockerfile + all CI workflows pin golang 1.27 in lock-step). Module: `github.com/Harsh-2002/Orva` (rooted at the repo, not at
 `backend/`). SQLite with no CGO (`modernc.org/sqlite`).
 
 The server binary built from `backend/cmd/orva` is the daemon (`orva serve`)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -383,7 +383,7 @@ BYO provider keys. Served at `/api/v1/ai/*` (SSE for chat + approval).
   normalized event stream. `Account` resolves BYO keys from
   `ai_provider_configs` at request time; thinking levels map to
   `ChatReasoning`. (The Bifrost dependency is why the module requires
-  Go ≥1.26.)
+  Go ≥1.27.)
 - `agent/` — the agentic loop (≈25-iteration budget): stream a model
   turn → emit SSE deltas → detect tool calls → approval-gate writes →
   dispatch the tool **in-process as a Go call** (no MCP transport, no

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,7 +24,7 @@ target list (`build`, `build-all`, `cli`, `cli-all`, `embed`, `adapters-embed`,
 
 Requires:
 
-- **Go 1.26+** (the embedded AI gateway requires it)
+- **Go 1.27+** (the embedded AI gateway requires it)
 - **Node 24+**
 - **nsjail** at exactly `/usr/local/bin/nsjail` — the path is hardcoded
   (`config/defaults.go`, pinned by `config_test.go`) and `PATH` is never

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -117,7 +117,7 @@ Say these out loud before you claim a change is verified:
 
 | Requirement | Why | Check |
 |---|---|---|
-| Go 1.26+ | the embedded Bifrost AI gateway needs it | `go version` |
+| Go 1.27+ | the embedded Bifrost AI gateway needs it | `go version` |
 | Node 24 | frontend build only — *not* the function runtime | `node --version` |
 | Python 3.14 (CONTRACT §1) | CI parity. The E2E suite is stdlib-only and **ran clean on 3.13.5** — do not go install 3.14 before you can run anything | `python3 -V` |
 | Linux, cgroup v2, unprivileged userns | nsjail | `mount \| grep cgroup2` |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Harsh-2002/Orva
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/matoous/go-nanoid/v2 v2.1.0
-	github.com/maximhq/bifrost/core v1.7.13
+	github.com/maximhq/bifrost/core v1.8.4
 	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
@@ -54,8 +54,8 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.2.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.15.2 // indirect
-	github.com/bytedance/sonic/loader v0.5.1 // indirect
+	github.com/bytedance/sonic v1.15.3-0.20260730064818-2a36d6da63e2 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.2 // indirect
@@ -70,7 +70,7 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.13.0 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,10 +74,10 @@ github.com/buger/jsonparser v1.2.0 h1:4EFcvK1kD4jyj6YqNK6skK6w+y7FHHBR+XBCtxwu/6
 github.com/buger/jsonparser v1.2.0/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.15.2 h1:90H+rcF/FwLXwfB1cudOLq/je83n683Utf4Cbp0xHCo=
-github.com/bytedance/sonic v1.15.2/go.mod h1:mT2NbXunuaEbnZ+mRIX/vYqKISmgEuHFDI4UzmKx2SA=
-github.com/bytedance/sonic/loader v0.5.1 h1:Ygpfa9zwRCCKSlrp5bBP/b/Xzc3VxsAW+5NIYXrOOpI=
-github.com/bytedance/sonic/loader v0.5.1/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.3-0.20260730064818-2a36d6da63e2 h1:XTVMfgtmKUmmdvQux2e0MjKVqbaJ7Yw8ngYXw5S6zYY=
+github.com/bytedance/sonic v1.15.3-0.20260730064818-2a36d6da63e2/go.mod h1:8e51yTPdY8M6t+vvGL1c2Y1xL9i+frEeIAQAEl75NUc=
+github.com/bytedance/sonic/loader v0.5.2 h1:0QtP1gevc1OZ6/H8Lb9BRZiCXd1Ftjd3OKuj1T1lBIo=
+github.com/bytedance/sonic/loader v0.5.2/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=
@@ -139,8 +139,8 @@ github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcI
 github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
-github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
-github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -167,8 +167,8 @@ github.com/mattn/go-isatty v0.0.24/go.mod h1:nMCL3Zebbrt45jsMDgnfIwz6ydEQApk5oEI
 github.com/mattn/go-runewidth v0.0.12/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/mattn/go-runewidth v0.0.17 h1:78v8ZlW0bP43XfmAfPsdXcoNCelfMHsDmd/pkENfrjQ=
 github.com/mattn/go-runewidth v0.0.17/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/maximhq/bifrost/core v1.7.13 h1:BQoIWq3/ee5IrNiNDJMQ2HmxwbIUu++VwLBRsi6j3kU=
-github.com/maximhq/bifrost/core v1.7.13/go.mod h1:XQGQ99V6iW2yRbq4zg5+LfDcJMR06x/Ie4HuC8FWEDI=
+github.com/maximhq/bifrost/core v1.8.4 h1:GWvGPxsC56xP8hCa5f/wKOZdilhd1eh91zxu5jYZ5xk=
+github.com/maximhq/bifrost/core v1.8.4/go.mod h1:mGZ8gaIiJsZkLkncbBjS2zImMN2tZRp2cq1MpiI5SLA=
 github.com/microcosm-cc/bluemonday v1.0.27 h1:MpEUotklkwCSLeH+Qdx1VJgNqLlpY2KXwXFM08ygZfk=
 github.com/microcosm-cc/bluemonday v1.0.27/go.mod h1:jFi9vgW+H7c3V0lb6nR74Ib/DIB5OBs92Dimizgw2cA=
 github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=

--- a/test/e2e/CLAUDE.md
+++ b/test/e2e/CLAUDE.md
@@ -36,7 +36,7 @@ python3 run.py --url http://127.0.0.1:8443 --api-key "$(sudo cat /var/lib/orva/.
 ```
 
 **Requirements:** `docker` (for isolated mode), `python3`, and a built `build/orva`
-(for the CLI tests — `make build` from repo root). The image build needs Go 1.26
+(for the CLI tests — `make build` from repo root). The image build needs Go 1.27
 (the Dockerfile pins it; the AI gateway requires it).
 
 ## Architecture


### PR DESCRIPTION
Supersedes #78, which could not merge on its own.

## Why this is not just a dependency bump

Dependabot's #78 bumped `bifrost/core` 1.7.13 → 1.8.4 and, as a side effect, rewrote go.mod's directive `go 1.26.6` → `go 1.27.0`. That directive change is real and unavoidable: `bifrost/core@v1.8.4` declares `go 1.27.0` in its own module.

CONTRACT.md §1 holds the toolchain lock-step across `Dockerfile`, `ci.yml` and `release.yml`. #78 moved only go.mod, so three CI jobs died on `go.mod requires go >= 1.27.0 (running go 1.26.8; GOTOOLCHAIN=local)`.

The Dockerfile is the hard failure: the official `golang` images set `GOTOOLCHAIN=local`, so `golang:1.26-bookworm` refuses to fetch 1.27 and fails at `go mod download` rather than silently upgrading. That takes out ci.yml's `docker` job, the gated `e2e` job (`test/e2e/env.py` builds the image), release.yml's `docker-image` job, and `docker compose`.

`ci.yml`'s `e2e` job passed on #78 throughout — it alone resolves its toolchain from `go-version-file: go.mod`. That inconsistency is what masked the breakage, and it needs no edit here.

This is the same lock-step miss `test/e2e/CLAUDE.md:97` already records from the 1.25 → 1.26 bump.

## What changed

**Toolchain pins (7):** `Dockerfile:16`, `ci.yml` 168/222/529/548, `release.yml` 153/246. `ci.yml:391` (`go-version-file: go.mod`) follows automatically.

**Docs, per CONTRACT §6a:** `CONTRACT.md:21`, `backend/CLAUDE.md:3`, `docs/CONTRIBUTING.md:27`, `docs/TESTING.md:120`, `docs/ARCHITECTURE.md:386`, `test/e2e/CLAUDE.md:39`, `README.md:7`. `test/e2e/CLAUDE.md:97` is left alone — it is a historical incident record, still accurate as history.

**`CHANGELOG.md`:** a new `## Unreleased` upgrade note. Building from source now needs Go 1.27; binary and container users are unaffected.

No Orva source changes.

## Verification

- Every bifrost symbol the `llm` package touches — the `Account` interface and its three methods, `bifrost.Init`/`NewNoOpLogger`/`Shutdown`, `BifrostConfig`, the `BifrostChatRequest`/`ChatParameters`/`ChatReasoning` family, the streaming chunk chain, `BifrostError`/`GetErrorString` — is unchanged in v1.8.4. Compared against the v1.8.4 and v1.7.13 module sources, not release notes.
- `go build ./...`, `go vet ./...`, `go test -count=1 ./...` all pass on go1.27.
- CLI builds at **16.4 MB** against the 28 MB ceiling in `test/cli/lib/common.sh`.
- `golang:1.27-bookworm` exists (pushed 2026-09-02).